### PR TITLE
Add Claude-generated commit messages to the done command

### DIFF
--- a/.claude/commands/docket:describe.md
+++ b/.claude/commands/docket:describe.md
@@ -1,0 +1,33 @@
+# Generate Commit Description
+
+Generate a commit message for the current changes following Google's CL description best practices.
+
+## Instructions
+
+1. Run `jj show` to see the current changes (files modified and diff)
+2. Run `cargo run -- show $DOCKET_BUG` to get the bug title and description for context
+
+## Commit Message Format
+
+**First line**: Short imperative summary of WHAT changed
+- Use imperative mood: "Add", "Fix", "Remove" (not "Added", "Fixing", "Removed")
+- Should be searchable and stand alone
+- Keep it concise but descriptive
+
+**Blank line**
+
+**Body**: Explain WHY this change was made
+- The problem being solved
+- Why this approach was chosen
+- Any context a future reader would need
+- Reference the bug ID naturally
+
+## Guidelines
+
+- The body explains reasoning, not just restates the diff
+- Future developers should understand whether they can safely modify this code
+- This will be a permanent part of version control history
+
+## Output
+
+Output ONLY the commit message text. No markdown formatting, no code blocks, no explanation - just the raw commit message ready to be passed to `jj describe`.

--- a/src/commands/status/done.rs
+++ b/src/commands/status/done.rs
@@ -1,5 +1,7 @@
 //! The `done` command workflow for completing bugs.
 
+use std::process::Command;
+
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 
@@ -8,6 +10,62 @@ use crate::event::Event;
 use crate::store::Store;
 
 use super::jj;
+
+/// Generate a commit message using Claude Code.
+/// Returns None if Claude fails (caller should fall back to simple message).
+fn generate_commit_message(bug_id: &str) -> Option<String> {
+    println!("{} Generating commit message with Claude...", "→".blue());
+
+    let output = Command::new("claude")
+        .args([
+            "-p",
+            "/docket:describe",
+            "--model",
+            "haiku",
+            "--allowedTools",
+            "Bash,Read",
+        ])
+        .env("DOCKET_BUG", bug_id)
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let message = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if message.is_empty() {
+                eprintln!(
+                    "{} Claude returned empty message, using fallback",
+                    "!".yellow()
+                );
+                None
+            } else {
+                Some(message)
+            }
+        }
+        Ok(output) => {
+            eprintln!(
+                "{} Claude failed (exit {}), using fallback message",
+                "!".yellow(),
+                output.status.code().unwrap_or(-1)
+            );
+            if !output.stderr.is_empty() {
+                eprintln!("{}", String::from_utf8_lossy(&output.stderr).dimmed());
+            }
+            None
+        }
+        Err(e) => {
+            eprintln!(
+                "{} Failed to run Claude ({}), using fallback message",
+                "!".yellow(),
+                e
+            );
+            None
+        }
+    }
+}
+
+fn fallback_commit_message(bug_title: &str, bug_id: &str) -> String {
+    format!("Implement {} ({})", bug_title, bug_id)
+}
 
 /// Mark a bug as done, handling workspace integration if applicable.
 pub fn done(id: &str) -> Result<()> {
@@ -62,8 +120,9 @@ pub fn done(id: &str) -> Result<()> {
             bug_id.cyan()
         );
 
-        // Set commit message (jj describe auto-snapshots, capturing the StatusChanged event)
-        let commit_message = format!("Implement {} ({})", bug_title, bug_id);
+        // Generate commit message using Claude, with fallback to simple message
+        let commit_message = generate_commit_message(&bug_id)
+            .unwrap_or_else(|| fallback_commit_message(&bug_title, &bug_id));
         jj::describe(&commit_message)?;
     }
 


### PR DESCRIPTION
This change integrates Claude Code to generate high-quality commit messages when marking bugs as done. Previously, the done command used a simple hardcoded message format. Now it invokes Claude with the /docket:describe skill to generate contextual, well-reasoned commit messages that explain the changes, with a fallback to the original simple format if Claude fails.

The integration handles three failure modes gracefully: when Claude is unavailable, when it exits with an error, or when it returns an empty response. This ensures the done command always succeeds and produces a usable commit message, while leveraging Claude's ability to write clear, maintainable change descriptions that future developers can learn from.