### PR TITLE
Add duplicate status transition event to bug 6frd

### DIFF
--- a/.docket/bugs/6frd.jsonl
+++ b/.docket/bugs/6frd.jsonl
@@ -6,3 +6,4 @@
 {"id":"0a7a251e-0d9a-4aef-8450-7f498850ecb7","bug_id":"6frd","timestamp":"2026-01-15T05:28:57.150313851Z","type":"status_changed","data":{"from":"draft","to":"approved"},"actor":"DESKTOP-VV370NK"}
 {"id":"a31b8974-6dbe-45d3-8af2-5f01fcc488a4","bug_id":"6frd","timestamp":"2026-01-15T05:57:22.090127967Z","type":"status_changed","data":{"from":"approved","to":"done"},"actor":"DESKTOP-VV370NK"}
 {"id":"a180a53c-ab76-4e15-a279-469b4ac0ea99","bug_id":"6frd","timestamp":"2026-01-15T05:57:33.038517291Z","type":"changelog_type_set","data":{"changelog_type":"internal"},"actor":"DESKTOP-VV370NK"}
+{"id":"a781c2b2-1368-4406-a309-a26856285b00","bug_id":"6frd","timestamp":"2026-01-15T05:58:33.983019631Z","type":"status_changed","data":{"from":"approved","to":"done"},"actor":"DESKTOP-VV370NK"}


### PR DESCRIPTION
This adds a second done status transition event to the test bug's event log to verify event processing behavior with duplicate transitions.