### PR TITLE
Typo and Help the LLM use docket update

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -171,7 +171,7 @@ pub fn new(
                     .join(", ")
             );
         }
-        println!("  Edit with: {} {}", "docket show".dimmed(), id.dimmed());
+        println!("  Edit with: {} {}", "docket edit".dimmed(), id.dimmed());
     }
 
     Ok(())

--- a/templates/docket-implement.md
+++ b/templates/docket-implement.md
@@ -21,6 +21,8 @@ You are helping implement a bug tracked by docket. Read the current bug context 
 
 4. **Update progress** as you work:
    - Use `docket update $DOCKET_BUG` to update the bug body with progress
+       - use - for stdin, example: `docket update $DOCKET_BUG --body -`
+       - use file for content, example: `docket update $DOCKET_BUG --body update.txt`
    - Add timestamped entries to the Log section describing what was accomplished
    - Format log entries as: `- YYYY-MM-DD: Description of progress`
    - Check off acceptance criteria by changing `- [ ]` to `- [x]`


### PR DESCRIPTION
While working with Claude code, I kept noticing it would stumble over how to execute the update. So I figured I would help it out by putting it in the instructions.

Also fixes what I believe to be a small typo in the command for Edit with