### PR TITLE
Add --edit flag to 'docket new' command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,10 @@ pub enum Commands {
         /// Create as a child step of an epic
         #[arg(short, long, add = ArgValueCompleter::new(complete_bug_id))]
         epic: Option<String>,
+
+        /// Open editor immediately after creation to edit the body
+        #[arg(long)]
+        edit: bool,
     },
 
     /// List all bugs

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -34,6 +34,7 @@ pub fn new(
     version: Option<&str>,
     tags: &[String],
     epic_id: Option<&str>,
+    edit: bool,
 ) -> Result<()> {
     let store = Store::open()?;
 
@@ -171,7 +172,14 @@ pub fn new(
                     .join(", ")
             );
         }
-        println!("  Edit with: {} {}", "docket edit".dimmed(), id.dimmed());
+        if !edit {
+            println!("  Edit with: {} {}", "docket edit".dimmed(), id.dimmed());
+        }
+    }
+
+    // Open editor if --edit flag was passed
+    if edit {
+        super::edit::edit(&id)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<()> {
             version,
             tag,
             epic,
+            edit,
         } => {
             let interactive = title.is_none();
             commands::new(
@@ -45,6 +46,7 @@ fn main() -> Result<()> {
                 version.as_deref(),
                 &tag,
                 epic.as_deref(),
+                edit,
             )
         }
         Commands::List {


### PR DESCRIPTION
## Summary
- Adds an `--edit` flag to `docket new` that opens the editor immediately after creating a bug
- Allows users to write up the issue details right away without a separate `docket edit` call

## Usage
```sh
docket new --edit
docket new --edit -t "My bug title"
```

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)