### PR TITLE
Add release management feature

### DIFF
--- a/.docket/releases/unscheduled.jsonl
+++ b/.docket/releases/unscheduled.jsonl
@@ -1,0 +1,1 @@
+{"version":1,"id":"22376c2b-2b98-4785-9a13-295d5ee7a7bc","release_version":"unscheduled","timestamp":"2026-01-25T23:31:43.125725Z","type":"created","data":{"version":"unscheduled","title":"Unscheduled","description":"Backlog items not yet assigned to a release."},"actor":"Steves-MacBook-Pro.local"}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "predicates",
  "rand",
  "sapling-renderdag",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -674,6 +675,12 @@ checksum = "edffb89cab87bd0901c5749d576f5d37a1f34e05160e936f463f4e94cc447b61"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ colored = "2"
 dialoguer = { version = "0.11", features = ["editor"] }
 anyhow = "1"
 toml = "0.8"
+semver = "1"
 tempfile = "3"
 sapling-renderdag = "0.1"
 

--- a/src/change.rs
+++ b/src/change.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 // Note: Utc is used in ChangeMetadata for created timestamp
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum Status {
     Draft,
@@ -251,6 +251,11 @@ impl FromStr for SortBy {
     }
 }
 
+/// Default target release for changes without an explicit release
+fn default_target_release() -> String {
+    crate::release::UNSCHEDULED_RELEASE.to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChangeMetadata {
     pub id: String,
@@ -260,6 +265,7 @@ pub struct ChangeMetadata {
     pub created: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changelog_type: Option<ChangelogType>,
+    /// Deprecated: use target_release instead. Kept for backward compatibility.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub versions: Vec<String>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
@@ -287,6 +293,9 @@ pub struct ChangeMetadata {
     /// Change IDs that this change is blocked by (inter-change dependencies)
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub blocked_by: HashSet<String>,
+    /// Target release version for this change (required, defaults to "unscheduled")
+    #[serde(default = "default_target_release")]
+    pub target_release: String,
 }
 
 #[derive(Debug, Clone)]
@@ -413,6 +422,16 @@ impl Change {
     /// Returns true if this change has any dependencies
     pub fn has_dependencies(&self) -> bool {
         !self.metadata.blocked_by.is_empty()
+    }
+
+    /// Returns the target release for this change
+    pub fn target_release(&self) -> &str {
+        &self.metadata.target_release
+    }
+
+    /// Returns true if this change is unscheduled (not assigned to a release)
+    pub fn is_unscheduled(&self) -> bool {
+        self.metadata.target_release == crate::release::UNSCHEDULED_RELEASE
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,7 @@ pub enum Commands {
         changelog: Option<String>,
 
         /// Version to assign to this change (can be added multiple times for backports)
+        /// DEPRECATED: use --release instead
         #[arg(short, long)]
         version: Option<String>,
 
@@ -82,6 +83,10 @@ pub enum Commands {
         /// Open editor immediately after creation to edit the body
         #[arg(long)]
         edit: bool,
+
+        /// Target release version (defaults to "unscheduled")
+        #[arg(short = 'r', long)]
+        release: Option<String>,
     },
 
     /// List all changes
@@ -122,11 +127,12 @@ pub enum Commands {
         #[arg(short, long)]
         interactive: bool,
 
-        /// Filter by version
+        /// Filter by version (DEPRECATED: use --release instead)
         #[arg(short, long)]
         version: Option<String>,
 
         /// Show only changes without a version (unreleased)
+        /// DEPRECATED: use --unscheduled instead
         #[arg(long)]
         no_version: bool,
 
@@ -149,6 +155,14 @@ pub enum Commands {
         /// Show as flat list instead of tree structure
         #[arg(long)]
         flat: bool,
+
+        /// Filter by target release version
+        #[arg(long, value_name = "VERSION")]
+        release: Option<String>,
+
+        /// Show only unscheduled changes (not assigned to any release)
+        #[arg(long)]
+        unscheduled: bool,
     },
 
     /// Show details of a change (uses current workspace change if no ID provided)
@@ -185,10 +199,12 @@ pub enum Commands {
         changelog: Option<String>,
 
         /// Add a version to this change (can be used multiple times for backports)
+        /// DEPRECATED: use 'docket release schedule' instead
         #[arg(short, long)]
         version: Option<String>,
 
         /// Remove a version from this change
+        /// DEPRECATED: use 'docket release schedule' instead
         #[arg(long)]
         remove_version: Option<String>,
     },
@@ -490,5 +506,87 @@ pub enum Commands {
         /// Show all changes including done and not-planned
         #[arg(short, long)]
         all: bool,
+    },
+
+    /// Manage releases (milestones)
+    #[command(subcommand)]
+    Release(ReleaseCommands),
+}
+
+#[derive(Subcommand)]
+pub enum ReleaseCommands {
+    /// Create a new release
+    New {
+        /// Semver version string (e.g., "1.0.0", "0.3.0-beta.1")
+        version: String,
+
+        /// Human-readable title (e.g., "Performance Release")
+        #[arg(short, long)]
+        title: Option<String>,
+
+        /// Read description from file (use - for stdin)
+        #[arg(short, long)]
+        body: Option<String>,
+
+        /// Target release date (YYYY-MM-DD)
+        #[arg(long)]
+        target_date: Option<String>,
+
+        /// Open editor immediately to write description
+        #[arg(long)]
+        edit: bool,
+    },
+
+    /// List releases
+    List {
+        /// Show all releases including released and cancelled
+        #[arg(short, long)]
+        all: bool,
+    },
+
+    /// Show release details and progress
+    Show {
+        /// Release version
+        version: String,
+    },
+
+    /// Edit release title and description
+    Edit {
+        /// Release version
+        version: String,
+    },
+
+    /// Activate a release (Planning -> Active)
+    Activate {
+        /// Release version
+        version: String,
+    },
+
+    /// Freeze a release (Active -> Frozen)
+    Freeze {
+        /// Release version
+        version: String,
+    },
+
+    /// Ship a release (Active/Frozen -> Released)
+    Ship {
+        /// Release version
+        version: String,
+    },
+
+    /// Cancel a release
+    Cancel {
+        /// Release version
+        version: String,
+    },
+
+    /// Schedule a change for a release
+    Schedule {
+        /// Change ID (prefix match supported)
+        #[arg(add = ArgValueCompleter::new(complete_change_id))]
+        change_id: String,
+
+        /// Target release version
+        version: String,
     },
 }

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -13,17 +13,22 @@ pub fn changelog(version: &str, preview: bool, file: Option<&str>) -> Result<()>
     let store = Store::open()?;
     let bugs = store.list_changes()?;
 
-    // Filter bugs that have this version
+    // Filter bugs that target this release OR have this version (legacy)
+    // Prefer target_release, but also check versions for backward compatibility
     let version_bugs: Vec<_> = bugs
         .into_iter()
-        .filter(|bug| bug.has_version(version))
+        .filter(|bug| bug.target_release() == version || bug.has_version(version))
         .collect();
 
     if version_bugs.is_empty() {
         println!(
-            "{} No changes found for version {}",
+            "{} No changes found for release {}",
             "!".yellow(),
             version.cyan()
+        );
+        println!(
+            "{}",
+            "Hint: Use 'docket release schedule <id> <version>' to assign changes.".dimmed()
         );
         return Ok(());
     }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 
 use crate::change::{Change, ChangelogType, Priority, SortBy, Status};
 use crate::commands::{approve, show, work};
+use crate::release::UNSCHEDULED_RELEASE;
 use crate::store::Store;
 
 #[allow(clippy::too_many_arguments)]
@@ -23,6 +24,8 @@ pub fn list(
     blocking_filter: bool,
     depends_on_filter: Option<&str>,
     flat: bool,
+    release_filter: Option<&str>,
+    unscheduled_only: bool,
 ) -> Result<()> {
     // Parse sort field early to catch invalid input
     let sort_by: SortBy = sort_by.parse().context("invalid sort field")?;
@@ -129,6 +132,18 @@ pub fn list(
                 if !bug.is_blocked_by(blocker_id) {
                     return false;
                 }
+            }
+
+            // Apply --release filter: show only bugs targeting a specific release
+            if let Some(release) = release_filter {
+                if bug.target_release() != release {
+                    return false;
+                }
+            }
+
+            // Apply --unscheduled filter: show only bugs not assigned to a release
+            if unscheduled_only && bug.target_release() != UNSCHEDULED_RELEASE {
+                return false;
             }
 
             true

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -235,6 +235,15 @@ pub fn log(id: &str, json: bool) -> Result<()> {
                 };
                 println!("    {}", display);
             }
+            EventData::ReleaseSet { release } => {
+                println!(
+                    "{} {} [{}]",
+                    timestamp.to_string().dimmed(),
+                    "release_set".magenta(),
+                    actor.dimmed()
+                );
+                println!("    Target release: {}", release.cyan());
+            }
         }
         println!();
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod list;
 pub mod log;
 pub mod new;
 pub mod ready;
+pub mod release;
 pub mod reparent;
 pub mod scratch;
 pub mod show;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -7,6 +7,7 @@ use std::io::{self, Read};
 use crate::change::{ChangelogType, Priority};
 use crate::config::Config;
 use crate::event::Event;
+use crate::release::{validate_version, UNSCHEDULED_RELEASE};
 use crate::store::Store;
 use crate::template::{self, TemplateContext};
 
@@ -35,8 +36,26 @@ pub fn new(
     tags: &[String],
     parent_id: Option<&str>,
     edit: bool,
+    release: Option<&str>,
 ) -> Result<()> {
     let store = Store::open()?;
+
+    // Validate release version if provided
+    let target_release = release.unwrap_or(UNSCHEDULED_RELEASE);
+    validate_version(target_release)?;
+
+    // Check that release exists
+    if !store.release_exists(target_release) {
+        store.ensure_unscheduled_release()?;
+        if !store.release_exists(target_release) {
+            return Err(anyhow::anyhow!(
+                "release '{}' does not exist\n\
+                 Create it with: docket release new {}",
+                target_release,
+                target_release
+            ));
+        }
+    }
 
     // If creating a child, verify the parent change exists
     let parent_change = if let Some(parent_ref) = parent_id {
@@ -129,9 +148,15 @@ pub fn new(
         tx.add_event(event);
     }
 
-    // Add VersionAdded event if version was provided
+    // Add VersionAdded event if version was provided (deprecated)
     if let Some(ver) = version {
         let event = Event::version_added(id.clone(), ver.to_string());
+        tx.add_event(event);
+    }
+
+    // Set the target release (if not unscheduled, add an explicit event)
+    if target_release != UNSCHEDULED_RELEASE {
+        let event = Event::release_set(id.clone(), target_release.to_string());
         tx.add_event(event);
     }
 
@@ -154,6 +179,9 @@ pub fn new(
         );
     } else {
         println!("{} Created change {} - {}", "✓".green(), id.cyan(), title);
+        if target_release != UNSCHEDULED_RELEASE {
+            println!("  Release: {}", target_release.cyan());
+        }
         if !tags.is_empty() {
             println!(
                 "  Tags: {}",

--- a/src/commands/release/edit.rs
+++ b/src/commands/release/edit.rs
@@ -1,0 +1,86 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use crate::release::ReleaseEvent;
+use crate::store::Store;
+
+pub fn edit(version: &str) -> Result<()> {
+    let store = Store::open()?;
+    let release = store.get_release(version)?;
+
+    // Prepare the content for editing
+    // Format: title on first line, blank line, description
+    let current_content = format!(
+        "{}\n\n{}",
+        release.title().unwrap_or(""),
+        release.description()
+    );
+
+    // Open editor
+    let edited = dialoguer::Editor::new()
+        .edit(&current_content)
+        .context("failed to open editor")?;
+
+    let edited = match edited {
+        Some(content) => content,
+        None => {
+            println!("{} No changes made", "→".blue());
+            return Ok(());
+        }
+    };
+
+    // Parse the edited content
+    // First non-empty line is title, rest is description
+    let lines: Vec<&str> = edited.lines().collect();
+    let new_title = lines
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim().to_string());
+
+    // Find where title ends and description begins
+    let title_end = lines
+        .iter()
+        .position(|l| !l.trim().is_empty())
+        .map(|i| i + 1)
+        .unwrap_or(0);
+
+    // Skip any blank lines after title
+    let desc_start = lines[title_end..]
+        .iter()
+        .position(|l| !l.trim().is_empty())
+        .map(|i| title_end + i)
+        .unwrap_or(lines.len());
+
+    let new_description: String = if desc_start < lines.len() {
+        lines[desc_start..].join("\n").trim().to_string()
+    } else {
+        String::new()
+    };
+
+    // Check if anything changed
+    let title_changed = new_title.as_deref() != release.title();
+    let description_changed = new_description != release.description();
+
+    if !title_changed && !description_changed {
+        println!("{} No changes made", "→".blue());
+        return Ok(());
+    }
+
+    // Create update event
+    let event = ReleaseEvent::updated(
+        version.to_string(),
+        if title_changed { new_title } else { None },
+        if description_changed {
+            Some(new_description)
+        } else {
+            None
+        },
+        None, // Don't change target_date via edit
+    );
+
+    store.append_release_event(&event)?;
+
+    println!("{} Updated release {}", "✓".green(), version.cyan().bold());
+
+    Ok(())
+}

--- a/src/commands/release/list.rs
+++ b/src/commands/release/list.rs
@@ -1,0 +1,96 @@
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::release::ReleaseStatus;
+use crate::store::Store;
+
+pub fn list(show_all: bool) -> Result<()> {
+    let store = Store::open()?;
+    let releases = store.list_releases()?;
+
+    if releases.is_empty() {
+        println!("{}", "No releases found.".dimmed());
+        return Ok(());
+    }
+
+    // Filter out Released/Cancelled unless --all is specified
+    let filtered: Vec<_> = releases
+        .into_iter()
+        .filter(|r| {
+            show_all
+                || !matches!(
+                    r.status(),
+                    ReleaseStatus::Released | ReleaseStatus::Cancelled
+                )
+        })
+        .collect();
+
+    if filtered.is_empty() {
+        println!("{}", "No active releases found.".dimmed());
+        println!(
+            "{}",
+            "Use --all to see released and cancelled releases.".dimmed()
+        );
+        return Ok(());
+    }
+
+    // Print header
+    println!(
+        "{:14} {:12} {:12} {:10} {}",
+        "VERSION".bold(),
+        "STATUS".bold(),
+        "TARGET".bold(),
+        "PROGRESS".bold(),
+        "TITLE".bold()
+    );
+    println!("{}", "-".repeat(70).dimmed());
+
+    for release in &filtered {
+        let status_str = format!("{}", release.status());
+        let status_colored = match release.status() {
+            ReleaseStatus::Planning => status_str.dimmed(),
+            ReleaseStatus::Active => status_str.green(),
+            ReleaseStatus::Frozen => status_str.cyan().bold(),
+            ReleaseStatus::Released => status_str.blue(),
+            ReleaseStatus::Cancelled => status_str.red(),
+        };
+
+        let target_str = release
+            .target_date()
+            .map(|d| d.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| "-".to_string());
+
+        // Get progress
+        let progress_str = match store.release_progress(release.version()) {
+            Ok((completed, total)) => {
+                if total == 0 {
+                    "-".to_string()
+                } else {
+                    let pct = (completed * 100) / total;
+                    if completed == total {
+                        format!("{}/{}", completed, total).green().to_string()
+                    } else {
+                        format!("{}/{} ({}%)", completed, total, pct)
+                    }
+                }
+            }
+            Err(_) => "?".to_string(),
+        };
+
+        let title = release.title().unwrap_or("-");
+
+        // Highlight unscheduled differently
+        let version_display = if release.is_unscheduled() {
+            release.version().yellow().to_string()
+        } else {
+            release.version().cyan().to_string()
+        };
+
+        println!(
+            "{:14} {:12} {:12} {:10} {}",
+            version_display, status_colored, target_str, progress_str, title
+        );
+    }
+
+    Ok(())
+}

--- a/src/commands/release/mod.rs
+++ b/src/commands/release/mod.rs
@@ -1,0 +1,13 @@
+pub mod edit;
+pub mod list;
+pub mod new;
+pub mod schedule;
+pub mod show;
+pub mod status;
+
+pub use edit::edit;
+pub use list::list;
+pub use new::new;
+pub use schedule::schedule;
+pub use show::show;
+pub use status::{activate, cancel, freeze, ship};

--- a/src/commands/release/new.rs
+++ b/src/commands/release/new.rs
@@ -1,0 +1,105 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{NaiveDate, Utc};
+use colored::Colorize;
+use std::fs;
+use std::io::{self, Read};
+
+use crate::release::{validate_version, ReleaseEvent, UNSCHEDULED_RELEASE};
+use crate::store::Store;
+
+/// Read body content from a file path or stdin (if path is "-")
+fn read_body_from_source(source: &str) -> Result<String> {
+    if source == "-" {
+        let mut content = String::new();
+        io::stdin()
+            .read_to_string(&mut content)
+            .context("failed to read body from stdin")?;
+        Ok(content)
+    } else {
+        fs::read_to_string(source).with_context(|| format!("failed to read body from '{}'", source))
+    }
+}
+
+/// Parse a date string in YYYY-MM-DD format
+fn parse_date(date_str: &str) -> Result<chrono::DateTime<Utc>> {
+    let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+        .with_context(|| format!("invalid date format '{}', expected YYYY-MM-DD", date_str))?;
+    Ok(date.and_hms_opt(0, 0, 0).unwrap().and_utc())
+}
+
+pub fn new(
+    version: &str,
+    title: Option<&str>,
+    body_source: Option<&str>,
+    target_date: Option<&str>,
+    edit: bool,
+) -> Result<()> {
+    // Validate version format
+    validate_version(version)?;
+
+    // Don't allow creating "unscheduled" manually
+    if version == UNSCHEDULED_RELEASE {
+        return Err(anyhow!(
+            "cannot create '{}' release - it is automatically created by docket",
+            UNSCHEDULED_RELEASE
+        ));
+    }
+
+    let store = Store::open()?;
+
+    // Check if release already exists
+    if store.release_exists(version) {
+        return Err(anyhow!(
+            "release '{}' already exists\n\
+             Use 'docket release show {}' to view it.",
+            version,
+            version
+        ));
+    }
+
+    // Get description from source if provided
+    let mut description = if let Some(source) = body_source {
+        read_body_from_source(source)?
+    } else {
+        String::new()
+    };
+
+    // Open editor if requested
+    if edit {
+        description = dialoguer::Editor::new()
+            .edit(&description)
+            .context("failed to open editor")?
+            .unwrap_or(description);
+    }
+
+    // Parse target date if provided
+    let target_date_parsed = target_date.map(parse_date).transpose()?;
+
+    // Create the release
+    let event = ReleaseEvent::created(
+        version.to_string(),
+        title.map(|s| s.to_string()),
+        description,
+        target_date_parsed,
+    );
+
+    store.append_release_event(&event)?;
+
+    println!("{} Created release {}", "✓".green(), version.cyan().bold());
+
+    if let Some(t) = title {
+        println!("  Title: {}", t);
+    }
+
+    if let Some(date) = target_date {
+        println!("  Target: {}", date);
+    }
+
+    println!(
+        "  View with: {} {}",
+        "docket release show".dimmed(),
+        version.dimmed()
+    );
+
+    Ok(())
+}

--- a/src/commands/release/schedule.rs
+++ b/src/commands/release/schedule.rs
@@ -1,0 +1,84 @@
+use anyhow::{anyhow, Result};
+use colored::Colorize;
+
+use crate::event::Event;
+use crate::release::{validate_version, ReleaseStatus, UNSCHEDULED_RELEASE};
+use crate::store::Store;
+
+pub fn schedule(change_id: &str, version: &str) -> Result<()> {
+    // Validate version format
+    validate_version(version)?;
+
+    let store = Store::open()?;
+
+    // Resolve change ID
+    let full_id = store.resolve_id(change_id)?;
+    let change = store.get_change(&full_id)?;
+
+    // Check if release exists
+    let release = store.get_release(version)?;
+
+    // Don't allow scheduling to Released/Cancelled releases
+    match release.status() {
+        ReleaseStatus::Released => {
+            return Err(anyhow!(
+                "cannot schedule change to released version '{}'\n\
+                 Create a new release version instead.",
+                version
+            ));
+        }
+        ReleaseStatus::Cancelled => {
+            return Err(anyhow!(
+                "cannot schedule change to cancelled release '{}'",
+                version
+            ));
+        }
+        ReleaseStatus::Frozen => {
+            // Allow but warn
+            println!(
+                "{} Release '{}' is frozen - change scope may require approval",
+                "!".yellow(),
+                version
+            );
+        }
+        _ => {}
+    }
+
+    // Check if already at this release
+    if change.target_release() == version {
+        println!(
+            "{} Change {} is already scheduled for {}",
+            "→".blue(),
+            full_id.cyan(),
+            version.cyan()
+        );
+        return Ok(());
+    }
+
+    let old_release = change.target_release().to_string();
+
+    // Create the event
+    let event = Event::release_set(full_id.clone(), version.to_string());
+    store.append_event(&event)?;
+
+    if old_release == UNSCHEDULED_RELEASE {
+        println!(
+            "{} Scheduled change {} for release {}",
+            "✓".green(),
+            full_id.cyan(),
+            version.cyan().bold()
+        );
+    } else {
+        println!(
+            "{} Moved change {} from {} to {}",
+            "✓".green(),
+            full_id.cyan(),
+            old_release.dimmed(),
+            version.cyan().bold()
+        );
+    }
+
+    println!("  {}", change.title());
+
+    Ok(())
+}

--- a/src/commands/release/show.rs
+++ b/src/commands/release/show.rs
@@ -1,0 +1,147 @@
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::change::Status;
+use crate::release::ReleaseStatus;
+use crate::store::Store;
+
+pub fn show(version: &str) -> Result<()> {
+    let store = Store::open()?;
+    let release = store.get_release(version)?;
+
+    // Print header
+    println!(
+        "{} {}",
+        release.version().cyan().bold(),
+        release
+            .title()
+            .map(|t| format!("- {}", t))
+            .unwrap_or_default()
+            .bold()
+    );
+    println!("{}", "-".repeat(60).dimmed());
+
+    // Print metadata
+    let status_str = format!("{}", release.status());
+    let status_colored = match release.status() {
+        ReleaseStatus::Planning => status_str.dimmed(),
+        ReleaseStatus::Active => status_str.green(),
+        ReleaseStatus::Frozen => status_str.cyan().bold(),
+        ReleaseStatus::Released => status_str.blue(),
+        ReleaseStatus::Cancelled => status_str.red(),
+    };
+
+    println!("{:12} {}", "Status:".dimmed(), status_colored);
+    println!(
+        "{:12} {}",
+        "Created:".dimmed(),
+        release.created().format("%Y-%m-%d %H:%M")
+    );
+
+    if let Some(target) = release.target_date() {
+        println!("{:12} {}", "Target:".dimmed(), target.format("%Y-%m-%d"));
+    }
+
+    if let Some(released) = release.released_date() {
+        println!(
+            "{:12} {}",
+            "Released:".dimmed(),
+            released.format("%Y-%m-%d")
+        );
+    }
+
+    // Get and display progress
+    let changes = store.get_changes_for_release(version)?;
+    let total = changes.len();
+    let completed = changes
+        .iter()
+        .filter(|c| matches!(c.status(), Status::Done))
+        .count();
+
+    if total > 0 {
+        let pct = (completed * 100) / total;
+        let progress_str = if completed == total {
+            format!("{}/{} (100%)", completed, total)
+                .green()
+                .to_string()
+        } else {
+            format!("{}/{} ({}%)", completed, total, pct)
+        };
+        println!("{:12} {}", "Progress:".dimmed(), progress_str);
+    } else {
+        println!("{:12} {}", "Changes:".dimmed(), "none".dimmed());
+    }
+
+    // Print description if present
+    if !release.description().is_empty() {
+        println!();
+        println!("{}", release.description());
+    }
+
+    // Print changes by status
+    if !changes.is_empty() {
+        println!();
+        println!("{}", "Changes:".bold());
+        println!("{}", "-".repeat(60).dimmed());
+
+        // Group by status
+        let mut by_status: std::collections::HashMap<Status, Vec<_>> =
+            std::collections::HashMap::new();
+        for change in &changes {
+            by_status
+                .entry(change.status().clone())
+                .or_default()
+                .push(change);
+        }
+
+        // Display order: Review, InProgress, Blocked, Approved, Draft, Done
+        let status_order = [
+            Status::Review,
+            Status::InProgress,
+            Status::Blocked,
+            Status::Approved,
+            Status::Draft,
+            Status::Paused,
+            Status::Done,
+            Status::NotPlanned,
+        ];
+
+        for status in &status_order {
+            if let Some(status_changes) = by_status.get(status) {
+                for change in status_changes {
+                    let change_status = change.status();
+                    let status_indicator = match change_status {
+                        Status::Done => "✓".green().to_string(),
+                        Status::Review => "⏳".to_string(),
+                        Status::InProgress => "→".yellow().to_string(),
+                        Status::Blocked => "✗".red().to_string(),
+                        Status::Paused => "⏸".cyan().to_string(),
+                        _ => "○".dimmed().to_string(),
+                    };
+
+                    let status_str = format!("{}", change_status);
+                    let status_colored = match change_status {
+                        Status::Draft => status_str.dimmed(),
+                        Status::Approved => status_str.green(),
+                        Status::InProgress => status_str.yellow(),
+                        Status::Blocked => status_str.red(),
+                        Status::Paused => status_str.cyan(),
+                        Status::Review => status_str.magenta(),
+                        Status::Done => status_str.blue(),
+                        Status::NotPlanned => status_str.red(),
+                    };
+
+                    println!(
+                        "  {} {} [{}] {}",
+                        status_indicator,
+                        change.id().cyan(),
+                        status_colored,
+                        change.title()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/release/status.rs
+++ b/src/commands/release/status.rs
@@ -1,0 +1,205 @@
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use colored::Colorize;
+
+use crate::release::{ReleaseEvent, ReleaseStatus, UNSCHEDULED_RELEASE};
+use crate::store::Store;
+
+/// Helper to check if a transition is valid and perform it
+fn transition(
+    store: &Store,
+    version: &str,
+    expected_from: &[ReleaseStatus],
+    to: ReleaseStatus,
+    action_verb: &str,
+) -> Result<()> {
+    // Prevent operations on unscheduled release
+    if version == UNSCHEDULED_RELEASE {
+        return Err(anyhow!(
+            "cannot {} the '{}' release - it is a special backlog release",
+            action_verb,
+            UNSCHEDULED_RELEASE
+        ));
+    }
+
+    let release = store.get_release(version)?;
+    let current = release.status();
+
+    // Check if transition is valid
+    if !expected_from.contains(current) {
+        let expected_str = expected_from
+            .iter()
+            .map(|s| format!("{}", s))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        return Err(anyhow!(
+            "cannot {} release '{}': current status is '{}', expected {}\n\
+             Run 'docket release show {}' to see current status.",
+            action_verb,
+            version,
+            current,
+            expected_str,
+            version
+        ));
+    }
+
+    // Create status change event
+    let event = ReleaseEvent::status_changed(version.to_string(), current.clone(), to.clone());
+    store.append_release_event(&event)?;
+
+    let status_str = format!("{}", to);
+    let status_colored = match to {
+        ReleaseStatus::Planning => status_str.dimmed(),
+        ReleaseStatus::Active => status_str.green(),
+        ReleaseStatus::Frozen => status_str.cyan().bold(),
+        ReleaseStatus::Released => status_str.blue(),
+        ReleaseStatus::Cancelled => status_str.red(),
+    };
+
+    println!(
+        "{} Release {} is now {}",
+        "✓".green(),
+        version.cyan().bold(),
+        status_colored
+    );
+
+    Ok(())
+}
+
+/// Transition Planning -> Active
+pub fn activate(version: &str) -> Result<()> {
+    let store = Store::open()?;
+    transition(
+        &store,
+        version,
+        &[ReleaseStatus::Planning],
+        ReleaseStatus::Active,
+        "activate",
+    )
+}
+
+/// Transition Active -> Frozen
+pub fn freeze(version: &str) -> Result<()> {
+    let store = Store::open()?;
+    transition(
+        &store,
+        version,
+        &[ReleaseStatus::Active],
+        ReleaseStatus::Frozen,
+        "freeze",
+    )
+}
+
+/// Transition Active/Frozen -> Released
+pub fn ship(version: &str) -> Result<()> {
+    let store = Store::open()?;
+
+    // Prevent operations on unscheduled release
+    if version == UNSCHEDULED_RELEASE {
+        return Err(anyhow!(
+            "cannot ship the '{}' release - it is a special backlog release",
+            UNSCHEDULED_RELEASE
+        ));
+    }
+
+    let release = store.get_release(version)?;
+    let current = release.status();
+
+    // Check if transition is valid
+    let valid_from = [ReleaseStatus::Active, ReleaseStatus::Frozen];
+    if !valid_from.contains(current) {
+        return Err(anyhow!(
+            "cannot ship release '{}': current status is '{}', expected active or frozen\n\
+             Run 'docket release show {}' to see current status.",
+            version,
+            current,
+            version
+        ));
+    }
+
+    // Create status change event
+    let status_event = ReleaseEvent::status_changed(
+        version.to_string(),
+        current.clone(),
+        ReleaseStatus::Released,
+    );
+    store.append_release_event(&status_event)?;
+
+    // Record the release date
+    let released_event = ReleaseEvent::released_at(version.to_string(), Utc::now());
+    store.append_release_event(&released_event)?;
+
+    println!(
+        "{} Release {} has been shipped!",
+        "✓".green(),
+        version.cyan().bold()
+    );
+
+    // Show summary
+    let (completed, total) = store.release_progress(version)?;
+    if total > 0 {
+        println!("  {} changes included ({} completed)", total, completed);
+    }
+
+    Ok(())
+}
+
+/// Transition any -> Cancelled
+pub fn cancel(version: &str) -> Result<()> {
+    let store = Store::open()?;
+
+    // Prevent operations on unscheduled release
+    if version == UNSCHEDULED_RELEASE {
+        return Err(anyhow!(
+            "cannot cancel the '{}' release - it is a special backlog release",
+            UNSCHEDULED_RELEASE
+        ));
+    }
+
+    let release = store.get_release(version)?;
+    let current = release.status();
+
+    // Can't cancel if already released or cancelled
+    if matches!(current, ReleaseStatus::Released) {
+        return Err(anyhow!(
+            "cannot cancel release '{}': it has already been released",
+            version
+        ));
+    }
+
+    if matches!(current, ReleaseStatus::Cancelled) {
+        println!(
+            "{} Release {} is already cancelled",
+            "→".blue(),
+            version.cyan()
+        );
+        return Ok(());
+    }
+
+    // Create status change event
+    let event = ReleaseEvent::status_changed(
+        version.to_string(),
+        current.clone(),
+        ReleaseStatus::Cancelled,
+    );
+    store.append_release_event(&event)?;
+
+    println!(
+        "{} Release {} has been cancelled",
+        "✓".green(),
+        version.cyan().bold()
+    );
+
+    // Warn about changes that were scheduled for this release
+    let (_, total) = store.release_progress(version)?;
+    if total > 0 {
+        println!(
+            "  {} {} changes were scheduled for this release",
+            "!".yellow(),
+            total
+        );
+        println!("  Use 'docket release schedule <id> <new-version>' to reschedule them");
+    }
+
+    Ok(())
+}

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use colored::Colorize;
 
 use crate::change::{Change, Status};
+use crate::release::UNSCHEDULED_RELEASE;
 use crate::store::Store;
 
 pub fn show(id: &str) -> Result<()> {
@@ -50,9 +51,17 @@ pub fn show(id: &str) -> Result<()> {
         println!("{:12} {}", "Changelog:".dimmed(), ct);
     }
 
-    // Show versions if any
+    // Show versions if any (deprecated, kept for compatibility)
     if !bug.versions().is_empty() {
         println!("{:12} {}", "Versions:".dimmed(), bug.versions().join(", "));
+    }
+
+    // Show target release
+    let release_str = bug.target_release();
+    if release_str == UNSCHEDULED_RELEASE {
+        println!("{:12} {}", "Release:".dimmed(), release_str.yellow());
+    } else {
+        println!("{:12} {}", "Release:".dimmed(), release_str.cyan());
     }
 
     // Show tags if any

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 use crate::change::{Change, ChangeMetadata, ChangelogType, Priority, Status};
+use crate::release::UNSCHEDULED_RELEASE;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "data")]
@@ -65,10 +66,14 @@ pub enum EventData {
         changelog_type: ChangelogType,
     },
     /// Add a version to a change (can have multiple versions for backports)
+    /// DEPRECATED: Use ReleaseSet and target_release instead.
+    /// Kept for backward compatibility with existing event logs.
     VersionAdded {
         version: String,
     },
     /// Remove a version from a change
+    /// DEPRECATED: Use ReleaseSet and target_release instead.
+    /// Kept for backward compatibility with existing event logs.
     VersionRemoved {
         version: String,
     },
@@ -103,6 +108,11 @@ pub enum EventData {
     ScratchpadAppended {
         /// Content to append to the scratchpad
         content: String,
+    },
+    /// Set the target release for a change
+    ReleaseSet {
+        /// The release version this change targets
+        release: String,
     },
 }
 
@@ -285,6 +295,10 @@ impl Event {
     pub fn dependency_removed(change_id: String, blocked_by: String) -> Self {
         Self::new(change_id, EventData::DependencyRemoved { blocked_by })
     }
+
+    pub fn release_set(change_id: String, release: String) -> Self {
+        Self::new(change_id, EventData::ReleaseSet { release })
+    }
 }
 
 /// Append an event to a change's JSONL file
@@ -382,6 +396,7 @@ pub fn derive_change(events: &[Event]) -> Result<Change> {
             blocked_reason: None,
             paused_reason: None,
             blocked_by: HashSet::new(),
+            target_release: UNSCHEDULED_RELEASE.to_string(),
         },
         body: initial_body,
     };
@@ -461,6 +476,9 @@ pub fn derive_change(events: &[Event]) -> Result<Change> {
                     change.metadata.scratchpad.push_str("\n\n");
                 }
                 change.metadata.scratchpad.push_str(content);
+            }
+            EventData::ReleaseSet { release } => {
+                change.metadata.target_release = release.clone();
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,9 @@ pub mod cli;
 pub mod commands;
 pub mod config;
 pub mod event;
+pub mod release;
 pub mod store;
 pub mod template;
 pub mod workspace;
 
-pub use cli::Cli;
+pub use cli::{Cli, ReleaseCommands};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use clap::Parser;
 
-use docket::cli::{Cli, Commands};
+use docket::cli::{Cli, Commands, ReleaseCommands};
 use docket::commands;
 use docket::workspace;
 
@@ -35,6 +35,7 @@ fn main() -> Result<()> {
             parent,
             epic,
             edit,
+            release,
         } => {
             let interactive = title.is_none();
             // parent takes precedence over epic (epic is legacy alias)
@@ -50,6 +51,7 @@ fn main() -> Result<()> {
                 &tag,
                 parent_id.as_deref(),
                 edit,
+                release.as_deref(),
             )
         }
         Commands::List {
@@ -69,6 +71,8 @@ fn main() -> Result<()> {
             blocking,
             depends_on,
             flat,
+            release,
+            unscheduled,
         } => {
             // --review and --blocked flags are shorthand for --status
             let status_filter = if review {
@@ -93,6 +97,8 @@ fn main() -> Result<()> {
                 blocking,
                 depends_on.as_deref(),
                 flat,
+                release.as_deref(),
+                unscheduled,
             )
         }
         Commands::Show { id } => {
@@ -215,5 +221,30 @@ fn main() -> Result<()> {
         Commands::Scratch { id, content } => commands::scratch(&id, &content),
         Commands::Reparent { id, parent } => commands::reparent(&id, parent.as_deref()),
         Commands::Graph { id, all } => commands::graph(id.as_deref(), all),
+        Commands::Release(release_cmd) => match release_cmd {
+            ReleaseCommands::New {
+                version,
+                title,
+                body,
+                target_date,
+                edit,
+            } => commands::release::new(
+                &version,
+                title.as_deref(),
+                body.as_deref(),
+                target_date.as_deref(),
+                edit,
+            ),
+            ReleaseCommands::List { all } => commands::release::list(all),
+            ReleaseCommands::Show { version } => commands::release::show(&version),
+            ReleaseCommands::Edit { version } => commands::release::edit(&version),
+            ReleaseCommands::Activate { version } => commands::release::activate(&version),
+            ReleaseCommands::Freeze { version } => commands::release::freeze(&version),
+            ReleaseCommands::Ship { version } => commands::release::ship(&version),
+            ReleaseCommands::Cancel { version } => commands::release::cancel(&version),
+            ReleaseCommands::Schedule { change_id, version } => {
+                commands::release::schedule(&change_id, &version)
+            }
+        },
     }
 }

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,0 +1,625 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::str::FromStr;
+use uuid::Uuid;
+
+/// Special release version for unscheduled/backlog items.
+/// This release cannot be Released or Cancelled.
+pub const UNSCHEDULED_RELEASE: &str = "unscheduled";
+
+/// Release status in its lifecycle
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReleaseStatus {
+    /// Deciding what goes in this release
+    Planning,
+    /// Actively developing
+    Active,
+    /// Code freeze - scope locked
+    Frozen,
+    /// Shipped
+    Released,
+    /// Abandoned
+    Cancelled,
+}
+
+impl ReleaseStatus {
+    fn sort_order(&self) -> u8 {
+        match self {
+            ReleaseStatus::Active => 0,    // Active releases first
+            ReleaseStatus::Frozen => 1,    // Then frozen (about to ship)
+            ReleaseStatus::Planning => 2,  // Then planning
+            ReleaseStatus::Released => 3,  // Then released
+            ReleaseStatus::Cancelled => 4, // Cancelled last
+        }
+    }
+}
+
+impl Ord for ReleaseStatus {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.sort_order().cmp(&other.sort_order())
+    }
+}
+
+impl PartialOrd for ReleaseStatus {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for ReleaseStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReleaseStatus::Planning => write!(f, "planning"),
+            ReleaseStatus::Active => write!(f, "active"),
+            ReleaseStatus::Frozen => write!(f, "frozen"),
+            ReleaseStatus::Released => write!(f, "released"),
+            ReleaseStatus::Cancelled => write!(f, "cancelled"),
+        }
+    }
+}
+
+impl FromStr for ReleaseStatus {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "planning" => Ok(ReleaseStatus::Planning),
+            "active" => Ok(ReleaseStatus::Active),
+            "frozen" | "freeze" => Ok(ReleaseStatus::Frozen),
+            "released" | "shipped" => Ok(ReleaseStatus::Released),
+            "cancelled" | "canceled" => Ok(ReleaseStatus::Cancelled),
+            _ => Err(anyhow!("unknown release status: {}", s)),
+        }
+    }
+}
+
+/// Metadata for a release
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseMetadata {
+    /// Semver version string (e.g., "0.3.0") - acts as ID
+    pub version: String,
+    /// Human-readable name (e.g., "Performance Release")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Current status in the release lifecycle
+    pub status: ReleaseStatus,
+    /// When the release was created
+    pub created: DateTime<Utc>,
+    /// Target release date
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_date: Option<DateTime<Utc>>,
+    /// Actual release date (set when status becomes Released)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub released_date: Option<DateTime<Utc>>,
+}
+
+/// A release with its description
+#[derive(Debug, Clone)]
+pub struct Release {
+    pub metadata: ReleaseMetadata,
+    /// Release theme/notes - what this release is about
+    pub description: String,
+}
+
+impl Release {
+    pub fn version(&self) -> &str {
+        &self.metadata.version
+    }
+
+    pub fn title(&self) -> Option<&str> {
+        self.metadata.title.as_deref()
+    }
+
+    pub fn status(&self) -> &ReleaseStatus {
+        &self.metadata.status
+    }
+
+    pub fn created(&self) -> DateTime<Utc> {
+        self.metadata.created
+    }
+
+    pub fn target_date(&self) -> Option<DateTime<Utc>> {
+        self.metadata.target_date
+    }
+
+    pub fn released_date(&self) -> Option<DateTime<Utc>> {
+        self.metadata.released_date
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Returns true if this is the special "unscheduled" release
+    pub fn is_unscheduled(&self) -> bool {
+        self.metadata.version == UNSCHEDULED_RELEASE
+    }
+
+    /// Returns a display name (title if set, otherwise version)
+    pub fn display_name(&self) -> &str {
+        self.metadata
+            .title
+            .as_deref()
+            .unwrap_or(&self.metadata.version)
+    }
+}
+
+/// Validate that a version string is valid semver.
+/// The special "unscheduled" version is exempt from validation.
+pub fn validate_version(version: &str) -> Result<()> {
+    if version == UNSCHEDULED_RELEASE {
+        return Ok(());
+    }
+
+    semver::Version::parse(version).with_context(|| {
+        format!(
+            "'{}' is not a valid semver version (e.g., '1.0.0', '0.3.0-beta.1')",
+            version
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Parse a version string into a semver Version.
+/// Returns None for the special "unscheduled" version.
+pub fn parse_version(version: &str) -> Option<semver::Version> {
+    if version == UNSCHEDULED_RELEASE {
+        return None;
+    }
+    semver::Version::parse(version).ok()
+}
+
+// ============================================================================
+// Release Event System
+// ============================================================================
+
+/// Event data for release events
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "data")]
+pub enum ReleaseEventData {
+    /// Release created
+    Created {
+        version: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(default)]
+        description: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_date: Option<DateTime<Utc>>,
+    },
+    /// Release status changed
+    StatusChanged {
+        from: ReleaseStatus,
+        to: ReleaseStatus,
+    },
+    /// Release updated (title, description, target_date)
+    Updated {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_date: Option<Option<DateTime<Utc>>>,
+    },
+    /// Release shipped at a specific date
+    ReleasedAt { date: DateTime<Utc> },
+}
+
+/// Current event schema version for release events.
+pub const CURRENT_RELEASE_EVENT_VERSION: u32 = 1;
+
+/// Default version for events that don't have a version field.
+fn default_version() -> u32 {
+    1
+}
+
+/// A release event
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseEvent {
+    /// Schema version for this event
+    #[serde(default = "default_version")]
+    pub version: u32,
+    /// Unique event ID
+    pub id: String,
+    /// Release version this event belongs to
+    pub release_version: String,
+    /// When this event occurred
+    pub timestamp: DateTime<Utc>,
+    /// The event data
+    #[serde(flatten)]
+    pub data: ReleaseEventData,
+    /// Actor (hostname) that created this event
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+}
+
+impl ReleaseEvent {
+    pub fn new(release_version: String, data: ReleaseEventData) -> Self {
+        ReleaseEvent {
+            version: CURRENT_RELEASE_EVENT_VERSION,
+            id: Uuid::new_v4().to_string(),
+            release_version,
+            timestamp: Utc::now(),
+            data,
+            actor: whoami::fallible::hostname().ok(),
+        }
+    }
+
+    pub fn created(
+        version: String,
+        title: Option<String>,
+        description: String,
+        target_date: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self::new(
+            version.clone(),
+            ReleaseEventData::Created {
+                version,
+                title,
+                description,
+                target_date,
+            },
+        )
+    }
+
+    pub fn status_changed(release_version: String, from: ReleaseStatus, to: ReleaseStatus) -> Self {
+        Self::new(
+            release_version,
+            ReleaseEventData::StatusChanged { from, to },
+        )
+    }
+
+    pub fn updated(
+        release_version: String,
+        title: Option<String>,
+        description: Option<String>,
+        target_date: Option<Option<DateTime<Utc>>>,
+    ) -> Self {
+        Self::new(
+            release_version,
+            ReleaseEventData::Updated {
+                title,
+                description,
+                target_date,
+            },
+        )
+    }
+
+    pub fn released_at(release_version: String, date: DateTime<Utc>) -> Self {
+        Self::new(release_version, ReleaseEventData::ReleasedAt { date })
+    }
+}
+
+/// Append an event to a release's JSONL file
+pub fn append_release_event(path: &Path, event: &ReleaseEvent) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+
+    let json = serde_json::to_string(event)?;
+    writeln!(file, "{}", json)?;
+    Ok(())
+}
+
+/// Read all events from a release's JSONL file
+pub fn read_release_events(path: &Path) -> Result<Vec<ReleaseEvent>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file =
+        fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+
+    for (line_num, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("failed to read line {}", line_num + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: ReleaseEvent = serde_json::from_str(&line)
+            .with_context(|| format!("failed to parse event on line {}", line_num + 1))?;
+        events.push(event);
+    }
+
+    // Sort by timestamp to ensure correct replay order
+    events.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    Ok(events)
+}
+
+/// Derive current release state by replaying events
+pub fn derive_release(events: &[ReleaseEvent]) -> Result<Release> {
+    if events.is_empty() {
+        return Err(anyhow!("no events to derive release from"));
+    }
+
+    // Find the Created event to get initial state
+    let created = events
+        .iter()
+        .find(|e| matches!(e.data, ReleaseEventData::Created { .. }))
+        .ok_or_else(|| anyhow!("no Created event found"))?;
+
+    let (initial_version, initial_title, initial_description, initial_target_date) =
+        match &created.data {
+            ReleaseEventData::Created {
+                version,
+                title,
+                description,
+                target_date,
+            } => (
+                version.clone(),
+                title.clone(),
+                description.clone(),
+                *target_date,
+            ),
+            _ => unreachable!(),
+        };
+
+    let mut release = Release {
+        metadata: ReleaseMetadata {
+            version: initial_version,
+            title: initial_title,
+            status: ReleaseStatus::Planning,
+            created: created.timestamp,
+            target_date: initial_target_date,
+            released_date: None,
+        },
+        description: initial_description,
+    };
+
+    // Replay all events in order
+    for event in events {
+        match &event.data {
+            ReleaseEventData::Created { .. } => {
+                // Already handled above
+            }
+            ReleaseEventData::StatusChanged { to, .. } => {
+                release.metadata.status = to.clone();
+            }
+            ReleaseEventData::Updated {
+                title,
+                description,
+                target_date,
+            } => {
+                if let Some(t) = title {
+                    release.metadata.title = Some(t.clone());
+                }
+                if let Some(d) = description {
+                    release.description = d.clone();
+                }
+                if let Some(td) = target_date {
+                    release.metadata.target_date = *td;
+                }
+            }
+            ReleaseEventData::ReleasedAt { date } => {
+                release.metadata.released_date = Some(*date);
+            }
+        }
+    }
+
+    Ok(release)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    fn make_event(
+        release_version: &str,
+        data: ReleaseEventData,
+        timestamp: DateTime<Utc>,
+    ) -> ReleaseEvent {
+        ReleaseEvent {
+            version: CURRENT_RELEASE_EVENT_VERSION,
+            id: "test-event-id".to_string(),
+            release_version: release_version.to_string(),
+            timestamp,
+            data,
+            actor: Some("test".to_string()),
+        }
+    }
+
+    #[test]
+    fn validate_version_valid_semver() {
+        assert!(validate_version("1.0.0").is_ok());
+        assert!(validate_version("0.3.0").is_ok());
+        assert!(validate_version("1.0.0-beta.1").is_ok());
+        assert!(validate_version("2.0.0-rc.1+build.123").is_ok());
+    }
+
+    #[test]
+    fn validate_version_invalid_semver() {
+        assert!(validate_version("1.0").is_err());
+        assert!(validate_version("v1.0.0").is_err());
+        assert!(validate_version("latest").is_err());
+        assert!(validate_version("").is_err());
+    }
+
+    #[test]
+    fn validate_version_unscheduled_allowed() {
+        assert!(validate_version(UNSCHEDULED_RELEASE).is_ok());
+    }
+
+    #[test]
+    fn parse_version_valid() {
+        let v = parse_version("1.2.3").unwrap();
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 2);
+        assert_eq!(v.patch, 3);
+    }
+
+    #[test]
+    fn parse_version_unscheduled_returns_none() {
+        assert!(parse_version(UNSCHEDULED_RELEASE).is_none());
+    }
+
+    #[test]
+    fn release_status_display() {
+        assert_eq!(ReleaseStatus::Planning.to_string(), "planning");
+        assert_eq!(ReleaseStatus::Active.to_string(), "active");
+        assert_eq!(ReleaseStatus::Frozen.to_string(), "frozen");
+        assert_eq!(ReleaseStatus::Released.to_string(), "released");
+        assert_eq!(ReleaseStatus::Cancelled.to_string(), "cancelled");
+    }
+
+    #[test]
+    fn release_status_from_str() {
+        assert_eq!(
+            ReleaseStatus::from_str("planning").unwrap(),
+            ReleaseStatus::Planning
+        );
+        assert_eq!(
+            ReleaseStatus::from_str("active").unwrap(),
+            ReleaseStatus::Active
+        );
+        assert_eq!(
+            ReleaseStatus::from_str("frozen").unwrap(),
+            ReleaseStatus::Frozen
+        );
+        assert_eq!(
+            ReleaseStatus::from_str("freeze").unwrap(),
+            ReleaseStatus::Frozen
+        );
+        assert_eq!(
+            ReleaseStatus::from_str("released").unwrap(),
+            ReleaseStatus::Released
+        );
+        assert_eq!(
+            ReleaseStatus::from_str("shipped").unwrap(),
+            ReleaseStatus::Released
+        );
+        assert_eq!(
+            ReleaseStatus::from_str("cancelled").unwrap(),
+            ReleaseStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn release_status_ordering() {
+        assert!(ReleaseStatus::Active < ReleaseStatus::Frozen);
+        assert!(ReleaseStatus::Frozen < ReleaseStatus::Planning);
+        assert!(ReleaseStatus::Planning < ReleaseStatus::Released);
+        assert!(ReleaseStatus::Released < ReleaseStatus::Cancelled);
+    }
+
+    #[test]
+    fn derive_release_from_created_event() {
+        let events = vec![make_event(
+            "1.0.0",
+            ReleaseEventData::Created {
+                version: "1.0.0".to_string(),
+                title: Some("Initial Release".to_string()),
+                description: "First release".to_string(),
+                target_date: None,
+            },
+            ts(1000),
+        )];
+
+        let release = derive_release(&events).unwrap();
+
+        assert_eq!(release.version(), "1.0.0");
+        assert_eq!(release.title(), Some("Initial Release"));
+        assert_eq!(release.description(), "First release");
+        assert_eq!(release.status(), &ReleaseStatus::Planning);
+    }
+
+    #[test]
+    fn derive_release_with_status_changes() {
+        let events = vec![
+            make_event(
+                "1.0.0",
+                ReleaseEventData::Created {
+                    version: "1.0.0".to_string(),
+                    title: None,
+                    description: "".to_string(),
+                    target_date: None,
+                },
+                ts(1000),
+            ),
+            make_event(
+                "1.0.0",
+                ReleaseEventData::StatusChanged {
+                    from: ReleaseStatus::Planning,
+                    to: ReleaseStatus::Active,
+                },
+                ts(2000),
+            ),
+        ];
+
+        let release = derive_release(&events).unwrap();
+        assert_eq!(release.status(), &ReleaseStatus::Active);
+    }
+
+    #[test]
+    fn derive_release_with_updates() {
+        let events = vec![
+            make_event(
+                "1.0.0",
+                ReleaseEventData::Created {
+                    version: "1.0.0".to_string(),
+                    title: None,
+                    description: "Original".to_string(),
+                    target_date: None,
+                },
+                ts(1000),
+            ),
+            make_event(
+                "1.0.0",
+                ReleaseEventData::Updated {
+                    title: Some("New Title".to_string()),
+                    description: Some("Updated description".to_string()),
+                    target_date: None,
+                },
+                ts(2000),
+            ),
+        ];
+
+        let release = derive_release(&events).unwrap();
+        assert_eq!(release.title(), Some("New Title"));
+        assert_eq!(release.description(), "Updated description");
+    }
+
+    #[test]
+    fn release_is_unscheduled() {
+        let release = Release {
+            metadata: ReleaseMetadata {
+                version: UNSCHEDULED_RELEASE.to_string(),
+                title: None,
+                status: ReleaseStatus::Planning,
+                created: Utc::now(),
+                target_date: None,
+                released_date: None,
+            },
+            description: String::new(),
+        };
+        assert!(release.is_unscheduled());
+
+        let release2 = Release {
+            metadata: ReleaseMetadata {
+                version: "1.0.0".to_string(),
+                title: None,
+                status: ReleaseStatus::Planning,
+                created: Utc::now(),
+                target_date: None,
+                released_date: None,
+            },
+            description: String::new(),
+        };
+        assert!(!release2.is_unscheduled());
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -8,9 +8,14 @@ use std::path::{Path, PathBuf};
 
 use crate::change::Change;
 use crate::event::{self, Event};
+use crate::release::{
+    self, append_release_event, derive_release, read_release_events, Release, ReleaseEvent,
+    UNSCHEDULED_RELEASE,
+};
 
 const DOCKET_DIR: &str = ".docket";
 const CHANGES_DIR: &str = "changes";
+const RELEASES_DIR: &str = "releases";
 const LEGACY_BUGS_DIR: &str = "bugs";
 const ID_CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
 const ID_LENGTH: usize = 4;
@@ -36,6 +41,9 @@ impl Store {
                 let store = Store { root: docket_path };
                 // Migrate from legacy bugs/ directory if needed
                 store.migrate_bugs_to_changes()?;
+                // Ensure releases directory exists (for repos created before releases feature)
+                store.ensure_releases_dir()?;
+                store.ensure_unscheduled_release()?;
                 return Ok(store);
             }
 
@@ -66,12 +74,21 @@ impl Store {
         fs::create_dir_all(&changes_dir)
             .with_context(|| format!("failed to create {}", changes_dir.display()))?;
 
+        let releases_dir = root.join(RELEASES_DIR);
+        fs::create_dir_all(&releases_dir)
+            .with_context(|| format!("failed to create {}", releases_dir.display()))?;
+
         // Create .gitignore for cache directory
         let gitignore_path = root.join(".gitignore");
         fs::write(&gitignore_path, ".cache/\n")
             .with_context(|| format!("failed to create {}", gitignore_path.display()))?;
 
-        Ok(Store { root })
+        let store = Store { root };
+
+        // Create the special "unscheduled" release
+        store.ensure_unscheduled_release()?;
+
+        Ok(store)
     }
 
     /// Migrate from legacy .docket/bugs/ directory to .docket/changes/
@@ -609,6 +626,170 @@ impl Store {
         })?;
 
         recover_file(&path)
+    }
+
+    // ========================================================================
+    // Release Methods
+    // ========================================================================
+
+    /// Path to the releases directory
+    fn releases_dir(&self) -> PathBuf {
+        self.root.join(RELEASES_DIR)
+    }
+
+    /// Ensure the releases directory exists
+    fn ensure_releases_dir(&self) -> Result<()> {
+        let dir = self.releases_dir();
+        if !dir.exists() {
+            fs::create_dir_all(&dir)
+                .with_context(|| format!("failed to create {}", dir.display()))?;
+        }
+        Ok(())
+    }
+
+    /// Path to a specific release's event log file
+    fn release_path(&self, version: &str) -> PathBuf {
+        self.releases_dir().join(format!("{}.jsonl", version))
+    }
+
+    /// Ensure the special "unscheduled" release exists
+    pub fn ensure_unscheduled_release(&self) -> Result<()> {
+        self.ensure_releases_dir()?;
+
+        let path = self.release_path(UNSCHEDULED_RELEASE);
+        if path.exists() {
+            return Ok(());
+        }
+
+        let event = ReleaseEvent::created(
+            UNSCHEDULED_RELEASE.to_string(),
+            Some("Unscheduled".to_string()),
+            "Backlog items not yet assigned to a release.".to_string(),
+            None,
+        );
+
+        append_release_event(&path, &event)?;
+
+        Ok(())
+    }
+
+    /// List all releases
+    pub fn list_releases(&self) -> Result<Vec<Release>> {
+        self.ensure_releases_dir()?;
+        self.ensure_unscheduled_release()?;
+
+        let releases_dir = self.releases_dir();
+        let pattern = releases_dir.join("*.jsonl");
+        let pattern_str = pattern
+            .to_str()
+            .ok_or_else(|| anyhow!("invalid path encoding"))?;
+
+        let mut releases = Vec::new();
+
+        for entry in glob::glob(pattern_str)? {
+            let path = entry?;
+            let events = read_release_events(&path)?;
+
+            match derive_release(&events) {
+                Ok(release) => releases.push(release),
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to derive release from {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        // Sort by status (active first), then by version
+        releases.sort_by(|a, b| {
+            let status_cmp = a.status().cmp(b.status());
+            if status_cmp == std::cmp::Ordering::Equal {
+                // Compare by semver if both are valid, otherwise alphabetically
+                let a_ver = release::parse_version(a.version());
+                let b_ver = release::parse_version(b.version());
+                match (a_ver, b_ver) {
+                    (Some(av), Some(bv)) => bv.cmp(&av), // Newer versions first
+                    (Some(_), None) => std::cmp::Ordering::Less, // Semver before non-semver
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => a.version().cmp(b.version()),
+                }
+            } else {
+                status_cmp
+            }
+        });
+
+        Ok(releases)
+    }
+
+    /// Get a specific release by version
+    pub fn get_release(&self, version: &str) -> Result<Release> {
+        self.ensure_releases_dir()?;
+
+        // Handle the unscheduled release specially
+        if version == UNSCHEDULED_RELEASE {
+            self.ensure_unscheduled_release()?;
+        }
+
+        let path = self.release_path(version);
+
+        if !path.exists() {
+            return Err(anyhow!(
+                "release not found: '{}'\n\
+                 Run 'docket release list' to see all releases.",
+                version
+            ));
+        }
+
+        let events = read_release_events(&path)?;
+        derive_release(&events)
+    }
+
+    /// Append an event to a release's event log
+    pub fn append_release_event(&self, event: &ReleaseEvent) -> Result<()> {
+        self.ensure_releases_dir()?;
+
+        let path = self.release_path(&event.release_version);
+        append_release_event(&path, event)
+    }
+
+    /// Check if a release exists
+    pub fn release_exists(&self, version: &str) -> bool {
+        let path = self.release_path(version);
+        path.exists()
+    }
+
+    /// Get all events for a release
+    pub fn get_release_events(&self, version: &str) -> Result<Vec<ReleaseEvent>> {
+        let path = self.release_path(version);
+        if !path.exists() {
+            return Err(anyhow!(
+                "release not found: '{}'\n\
+                 Run 'docket release list' to see all releases.",
+                version
+            ));
+        }
+        read_release_events(&path)
+    }
+
+    /// Get changes for a specific release
+    pub fn get_changes_for_release(&self, version: &str) -> Result<Vec<Change>> {
+        let changes = self.list_changes()?;
+        Ok(changes
+            .into_iter()
+            .filter(|c| c.target_release() == version)
+            .collect())
+    }
+
+    /// Count changes by status for a release (returns (completed, total))
+    pub fn release_progress(&self, version: &str) -> Result<(usize, usize)> {
+        let changes = self.get_changes_for_release(version)?;
+        let completed = changes
+            .iter()
+            .filter(|c| matches!(c.status(), crate::change::Status::Done))
+            .count();
+        Ok((completed, changes.len()))
     }
 }
 


### PR DESCRIPTION
Releases are now first-class entities in docket, separate from changes. They act like GitHub milestones - grouping changes targeted for a specific version with their own lifecycle.

Key changes:
- New Release entity with lifecycle: Planning → Active → Frozen → Released
- Special "unscheduled" release for backlog items (auto-created)
- Every change has a target_release field (defaults to "unscheduled")
- Semver validation for release versions
- Release commands: new, list, show, edit, activate, freeze, ship, cancel, schedule
- Integration with existing commands: new --release, list --release/--unscheduled
- Changelog generation uses target_release (versions field deprecated)

Storage: Releases stored in .docket/releases/{version}.jsonl using event sourcing.