### PR TITLE
Fix docket done to use workspace when available

### DIFF
--- a/.docket/changes/m/mmjt.jsonl
+++ b/.docket/changes/m/mmjt.jsonl
@@ -1,0 +1,3 @@
+{"version":1,"id":"d2a6eb54-4469-45c4-832c-6f7ca2e83034","change_id":"mmjt","timestamp":"2026-01-26T00:54:19.406362Z","type":"created","data":{"title":"Fix docket done to use workspace when available","priority":"medium","body":""},"actor":"Steves-MacBook-Pro.local"}
+{"version":1,"id":"f0bd7d75-0629-4f48-bfbe-a3a1dbadcea3","change_id":"mmjt","timestamp":"2026-01-26T00:54:19.406479Z","type":"status_changed","data":{"from":"draft","to":"done"},"actor":"Steves-MacBook-Pro.local"}
+{"version":1,"id":"bb0fa5a2-faf7-4262-b2bf-d48519ec4bbf","change_id":"mmjt","timestamp":"2026-01-26T00:54:19.406482Z","type":"release_set","data":{"release":"0.3.0"},"actor":"Steves-MacBook-Pro.local"}

--- a/src/commands/status/done.rs
+++ b/src/commands/status/done.rs
@@ -258,7 +258,7 @@ pub fn done(
         }
     }
 
-    // Determine if workspace operations are needed
+    // Determine if workspace operations are needed (for later logic)
     let needs_workspace = describe || squash || submit;
 
     // Track if we switched directories (so we can switch back)
@@ -268,8 +268,8 @@ pub fn done(
     // Check if we're running from a workspace
     let mut in_workspace = jj::is_in_workspace(&bug_id);
 
-    // If workspace operations are requested and not in workspace, try to switch to it
-    if needs_workspace && !in_workspace {
+    // If not in workspace, try to switch to it so status event is written there
+    if !in_workspace {
         if let Some(workspace_dir) = jj::find_workspace_dir(&bug_id) {
             println!(
                 "{} Found workspace at {}, switching...",


### PR DESCRIPTION
Previously, 'docket done <id>' without --describe/--squash/--submit flags would write the status event to the current directory's .docket/ instead of switching to the workspace first. This could cause merge conflicts or inconsistent state when the workspace was later integrated.

Now the command always switches to the workspace (if one exists) before writing the status event, ensuring the change is part of the workspace's commit history.