### PR TITLE
Fix done command writing status event to wrong workspace

### DIFF
--- a/.docket/changes/c/c236.jsonl
+++ b/.docket/changes/c/c236.jsonl
@@ -1,0 +1,3 @@
+{"version":1,"id":"3298cce6-f57e-4e5b-8096-670383cb6252","change_id":"c236","timestamp":"2026-01-26T03:12:43.343947Z","type":"created","data":{"title":"Fix done command writing status event to wrong workspace","priority":"medium","body":""},"actor":"Steves-MacBook-Pro.local"}
+{"version":1,"id":"24a785d8-8f95-4469-92bd-0af5c2a09254","change_id":"c236","timestamp":"2026-01-26T03:12:43.344130Z","type":"status_changed","data":{"from":"draft","to":"done"},"actor":"Steves-MacBook-Pro.local"}
+{"version":1,"id":"56300c67-0b5e-4260-97c1-9e7bd516a5de","change_id":"c236","timestamp":"2026-01-26T03:12:43.344155Z","type":"changelog_type_set","data":{"changelog_type":"fix"},"actor":"Steves-MacBook-Pro.local"}

--- a/src/commands/status/done.rs
+++ b/src/commands/status/done.rs
@@ -298,7 +298,7 @@ pub fn done(
 
     // Switch to workspace if needed for jj operations
     let needs_workspace_switch = (do_describe || squash || submit) && !in_workspace;
-    if needs_workspace_switch {
+    let store = if needs_workspace_switch {
         if let Some(ref ws_dir) = workspace_dir {
             println!(
                 "{} Found workspace at {}, switching...",
@@ -308,11 +308,15 @@ pub fn done(
             std::env::set_current_dir(ws_dir)?;
             switched_to_workspace = true;
             in_workspace = true;
+            // Re-open store from workspace so events are written to the workspace's
+            // .docket/ directory, making them part of the workspace commit
+            Store::open()?
+        } else {
+            store
         }
-    }
-
-    // Note: We keep using the original store opened above for event writes.
-    // The directory switch is only for jj commands (squash, describe, submit).
+    } else {
+        store
+    };
 
     // Perform squash first (before describe, so the squashed commit gets the message)
     if squash && in_workspace {


### PR DESCRIPTION
When running 'docket done' from trunk with an existing workspace, the status change event was being written to trunk's .docket/ directory instead of the workspace's. This caused the change to appear modified in trunk after the command completed.

The fix re-opens the store after switching to the workspace directory, so the event is written to the workspace's .docket/ and becomes part of the workspace commit.