### PR TITLE
Fix StateBranch mode to actually write files to state branch

### DIFF
--- a/src/commands/status/jj.rs
+++ b/src/commands/status/jj.rs
@@ -538,108 +538,114 @@ pub fn list_state_files(pattern: &str) -> Result<Vec<String>> {
 /// Write content to a file on the state branch atomically.
 ///
 /// This function performs an atomic write by:
-/// 1. Creating a new child commit of docket-state (without editing working copy)
-/// 2. Writing the file content to that commit
-/// 3. Describing the commit with the provided message
-/// 4. Squashing the commit back into docket-state
+/// 1. Saving the current change ID
+/// 2. Editing the state branch (switching working copy)
+/// 3. Cleaning up the working directory (orphan branch has no .gitignore)
+/// 4. Writing the file to disk
+/// 5. Describing the commit
+/// 6. Returning to the original change
 ///
-/// If any step fails, the state branch is left unchanged.
+/// If any step fails, the function attempts to restore the original state.
 pub fn write_to_state_branch(path: &str, content: &str, message: &str) -> Result<()> {
-    // Step 1: Create a new commit from docket-state without editing it
-    // Using --no-edit to stay at current working copy position
-    let new_output = Command::new("jj")
-        .args(["new", STATE_BRANCH, "--no-edit"])
-        .output()
-        .context("failed to run jj new")?;
+    use std::fs;
 
-    if !new_output.status.success() {
-        let stderr = String::from_utf8_lossy(&new_output.stderr);
-        return Err(anyhow!("jj new {} failed: {}", STATE_BRANCH, stderr.trim()));
-    }
+    // Get workspace root
+    let workspace_root = workspace_root()?;
 
-    // Parse the new commit ID from stdout
-    // jj new --no-edit outputs something like "Created new commit <change_id>"
-    let stdout = String::from_utf8_lossy(&new_output.stdout);
-    let stderr = String::from_utf8_lossy(&new_output.stderr);
+    // Save the current change ID so we can return to it
+    let original_change = current_change_id()?;
 
-    // The change_id is typically in the output - we need to find it
-    // jj typically outputs to stderr for status messages
-    // Look for the change ID pattern (alphanumeric string after "Created new commit")
-    let combined = format!("{}{}", stdout, stderr);
-
-    // Find the new commit - look for a word that looks like a change_id
-    // jj outputs something like "Created new commit pqrstuvw" or similar
-    let new_change_id = combined
-        .lines()
-        .find(|line| line.contains("Created") || line.contains("created"))
-        .and_then(|line| {
-            // Extract the last word which should be the change_id
-            line.split_whitespace().last()
-        })
-        .ok_or_else(|| anyhow!("could not find new commit ID in jj output: {}", combined))?;
-
-    // Clean up helper - abandon the new commit if something goes wrong
-    let cleanup = |change_id: &str| {
-        let _ = Command::new("jj").args(["abandon", change_id]).output();
+    // Helper to restore original change on error
+    let restore = || {
+        let _ = Command::new("jj").args(["edit", &original_change]).output();
     };
 
-    // Step 2: Write the file content to the new commit
-    // Use jj file write with stdin for the content
-    let mut write_cmd = Command::new("jj")
-        .args(["file", "write", "-r", new_change_id, path])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .context("failed to spawn jj file write")?;
-
-    // Write content to stdin
-    if let Some(ref mut stdin) = write_cmd.stdin {
-        use std::io::Write;
-        stdin
-            .write_all(content.as_bytes())
-            .context("failed to write content to jj file write stdin")?;
-    }
-
-    let write_output = write_cmd
-        .wait_with_output()
-        .context("failed to wait for jj file write")?;
-
-    if !write_output.status.success() {
-        let stderr = String::from_utf8_lossy(&write_output.stderr);
-        cleanup(new_change_id);
-        return Err(anyhow!("jj file write failed: {}", stderr.trim()));
-    }
-
-    // Step 3: Describe the commit
-    let describe_output = Command::new("jj")
-        .args(["describe", "-r", new_change_id, "-m", message])
+    // Step 1: Edit the state branch (switch working copy to it)
+    let edit_output = Command::new("jj")
+        .args(["edit", STATE_BRANCH])
         .output()
-        .context("failed to run jj describe")?;
+        .context("failed to run jj edit")?;
 
-    if !describe_output.status.success() {
-        let stderr = String::from_utf8_lossy(&describe_output.stderr);
-        cleanup(new_change_id);
-        return Err(anyhow!("jj describe failed: {}", stderr.trim()));
-    }
-
-    // Step 4: Squash the new commit into docket-state
-    let squash_output = Command::new("jj")
-        .args(["squash", "-r", new_change_id, "--into", STATE_BRANCH])
-        .output()
-        .context("failed to run jj squash")?;
-
-    if !squash_output.status.success() {
-        let stderr = String::from_utf8_lossy(&squash_output.stderr);
-        cleanup(new_change_id);
+    if !edit_output.status.success() {
+        let stderr = String::from_utf8_lossy(&edit_output.stderr);
         return Err(anyhow!(
-            "jj squash into {} failed: {}",
+            "failed to edit {}: {}",
             STATE_BRANCH,
             stderr.trim()
         ));
     }
 
+    // Step 2: Clean up the working directory
+    // The orphan branch doesn't have .gitignore, so gitignored files
+    // (like target/) would appear as untracked. We must clean them up.
+    if let Err(e) = cleanup_working_directory(&workspace_root) {
+        restore();
+        return Err(e);
+    }
+
+    // Step 3: Write the file to the working copy
+    let full_path = Path::new(&workspace_root).join(path);
+
+    // Create parent directories if needed
+    if let Some(parent) = full_path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            restore();
+            return Err(anyhow!(
+                "failed to create directory {}: {}",
+                parent.display(),
+                e
+            ));
+        }
+    }
+
+    // Write the file
+    if let Err(e) = fs::write(&full_path, content) {
+        restore();
+        return Err(anyhow!("failed to write {}: {}", full_path.display(), e));
+    }
+
+    // Step 4: Describe the commit (this also snapshots the changes)
+    let describe_output = Command::new("jj")
+        .args(["describe", "-m", message])
+        .output()
+        .context("failed to run jj describe")?;
+
+    if !describe_output.status.success() {
+        let stderr = String::from_utf8_lossy(&describe_output.stderr);
+        restore();
+        return Err(anyhow!("jj describe failed: {}", stderr.trim()));
+    }
+
+    // Step 5: Return to the original change
+    let return_output = Command::new("jj")
+        .args(["edit", &original_change])
+        .output()
+        .context("failed to run jj edit")?;
+
+    if !return_output.status.success() {
+        let stderr = String::from_utf8_lossy(&return_output.stderr);
+        return Err(anyhow!(
+            "failed to return to original change: {}",
+            stderr.trim()
+        ));
+    }
+
     Ok(())
+}
+
+/// Get the jj workspace root directory.
+fn workspace_root() -> Result<String> {
+    let output = Command::new("jj")
+        .args(["workspace", "root"])
+        .output()
+        .context("failed to run jj workspace root")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("jj workspace root failed: {}", stderr.trim()));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Clean up the working directory when on an orphan branch.

--- a/src/store.rs
+++ b/src/store.rs
@@ -63,14 +63,16 @@ impl Store {
     ///
     /// Detection order:
     /// 1. Find repo root (look for .jj or .git)
-    /// 2. Check if docket-state bookmark exists → StateBranch mode
-    /// 3. Check if .docket directory exists → FileSystem mode
+    /// 2. Check if docket-state bookmark exists → StateBranch mode (takes priority)
+    /// 3. Check if .docket directory exists → FileSystem mode (fallback)
     /// 4. Neither → error
     pub fn open_from(start: &Path) -> Result<Self> {
         let mut current = start.to_path_buf();
 
         // Track if we find a repo root (for potential state branch mode)
         let mut repo_root: Option<PathBuf> = None;
+        // Track if we find a .docket directory (for potential filesystem mode)
+        let mut docket_dir: Option<PathBuf> = None;
 
         loop {
             // Check for repo root (.jj or .git)
@@ -80,22 +82,12 @@ impl Store {
                 repo_root = Some(current.clone());
             }
 
-            // Check for .docket directory (FileSystem mode)
-            let docket_path = current.join(DOCKET_DIR);
-            if docket_path.is_dir() {
-                let mode = StoreMode::FileSystem {
-                    root: docket_path.clone(),
-                };
-                let store = Store {
-                    mode,
-                    root: docket_path,
-                };
-                // Migrate from legacy bugs/ directory if needed
-                store.migrate_bugs_to_changes()?;
-                // Ensure releases directory exists (for repos created before releases feature)
-                store.ensure_releases_dir()?;
-                store.ensure_unscheduled_release()?;
-                return Ok(store);
+            // Check for .docket directory (potential FileSystem mode)
+            if docket_dir.is_none() {
+                let docket_path = current.join(DOCKET_DIR);
+                if docket_path.is_dir() {
+                    docket_dir = Some(docket_path);
+                }
             }
 
             if !current.pop() {
@@ -103,9 +95,10 @@ impl Store {
             }
         }
 
-        // If we found a repo root, check for state branch
-        if let Some(repo_root) = repo_root {
-            if Self::has_state_branch(&repo_root)? {
+        // Priority 1: If we found a repo root, check for state branch first
+        // StateBranch mode takes priority over FileSystem mode when both exist
+        if let Some(ref repo_root) = repo_root {
+            if Self::has_state_branch(repo_root)? {
                 // StateBranch mode - data is stored on the docket-state branch
                 // The root path is virtual (used for consistency but not for actual file access)
                 let virtual_root = repo_root.join(DOCKET_DIR);
@@ -117,6 +110,23 @@ impl Store {
                     root: virtual_root,
                 });
             }
+        }
+
+        // Priority 2: Fall back to FileSystem mode if .docket directory exists
+        if let Some(docket_path) = docket_dir {
+            let mode = StoreMode::FileSystem {
+                root: docket_path.clone(),
+            };
+            let store = Store {
+                mode,
+                root: docket_path,
+            };
+            // Migrate from legacy bugs/ directory if needed
+            store.migrate_bugs_to_changes()?;
+            // Ensure releases directory exists (for repos created before releases feature)
+            store.ensure_releases_dir()?;
+            store.ensure_unscheduled_release()?;
+            return Ok(store);
         }
 
         Err(anyhow!(
@@ -309,6 +319,16 @@ impl Store {
             return Some(flat);
         }
         None
+    }
+
+    /// Check if a change exists (works in both FileSystem and StateBranch modes)
+    fn change_exists(&self, id: &str) -> Result<bool> {
+        if self.is_state_branch_mode() {
+            let all_ids = self.list_all_change_ids_state_branch()?;
+            Ok(all_ids.contains(&id.to_string()))
+        } else {
+            Ok(self.find_change_path(id).is_some())
+        }
     }
 
     /// Migrate a change file from flat to sharded structure if needed
@@ -515,6 +535,12 @@ impl Store {
 
     /// Find all change IDs in the repository (for fuzzy matching)
     fn list_all_change_ids(&self) -> Result<Vec<String>> {
+        // Dispatch to correct implementation based on mode
+        if self.is_state_branch_mode() {
+            return self.list_all_change_ids_state_branch();
+        }
+
+        // FileSystem mode
         let changes_dir = self.changes_dir();
         let mut ids = Vec::new();
         let mut seen = std::collections::HashSet::new();
@@ -545,6 +571,22 @@ impl Store {
             }
         }
 
+        Ok(ids)
+    }
+
+    /// List all change IDs from the state branch
+    fn list_all_change_ids_state_branch(&self) -> Result<Vec<String>> {
+        let files = jj::list_state_files(".docket/changes/*/*.jsonl")?;
+        let ids: Vec<String> = files
+            .iter()
+            .filter_map(|path| {
+                // Extract ID from path like ".docket/changes/a/abc1.jsonl"
+                let path = std::path::Path::new(path);
+                path.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+            })
+            .collect();
         Ok(ids)
     }
 
@@ -647,7 +689,12 @@ impl Store {
 
     /// Resolve a change ID prefix to the full ID (supports prefix and fuzzy matching)
     pub fn resolve_id(&self, id: &str) -> Result<String> {
-        // First try exact match (checks sharded then flat)
+        // Dispatch to correct implementation based on mode
+        if self.is_state_branch_mode() {
+            return self.resolve_id_state_branch(id);
+        }
+
+        // FileSystem mode: First try exact match (checks sharded then flat)
         if self.find_change_path(id).is_some() {
             return Ok(id.to_string());
         }
@@ -695,6 +742,49 @@ impl Store {
         }
     }
 
+    /// Resolve a change ID in StateBranch mode
+    fn resolve_id_state_branch(&self, id: &str) -> Result<String> {
+        let all_ids = self.list_all_change_ids_state_branch()?;
+
+        // First try exact match
+        if all_ids.contains(&id.to_string()) {
+            return Ok(id.to_string());
+        }
+
+        // Try prefix match
+        let prefix_matches: Vec<_> = all_ids
+            .iter()
+            .filter(|change_id| change_id.starts_with(id))
+            .cloned()
+            .collect();
+
+        match prefix_matches.len() {
+            0 => {
+                // No prefix matches, try fuzzy matching
+                let fuzzy_matches = self.find_fuzzy_matches(id)?;
+                match fuzzy_matches.len() {
+                    0 => Err(anyhow!(
+                        "change not found: '{}'\n\
+                         Run 'docket list' to see all changes.",
+                        id
+                    )),
+                    1 => Ok(fuzzy_matches[0].clone()),
+                    _ => Err(anyhow!(
+                        "ambiguous change ID '{}', fuzzy matches: {}",
+                        id,
+                        fuzzy_matches.join(", ")
+                    )),
+                }
+            }
+            1 => Ok(prefix_matches[0].clone()),
+            _ => Err(anyhow!(
+                "ambiguous change ID '{}', matches: {}",
+                id,
+                prefix_matches.join(", ")
+            )),
+        }
+    }
+
     /// Generate a unique change ID
     pub fn generate_id(&self) -> Result<String> {
         let mut rng = rand::thread_rng();
@@ -708,8 +798,8 @@ impl Store {
                 })
                 .collect();
 
-            // Check both sharded and flat paths to ensure uniqueness
-            if self.find_change_path(&id).is_none() {
+            // Check uniqueness across all modes
+            if !self.change_exists(&id)? {
                 return Ok(id);
             }
         }
@@ -849,11 +939,26 @@ impl Store {
         }
 
         match prefix_matches.len() {
-            0 => Err(anyhow!(
-                "change not found: '{}'\n\
-                 Run 'docket list' to see all changes, or 'docket new' to create one.",
-                id
-            )),
+            0 => {
+                // No prefix matches, try fuzzy matching
+                let fuzzy_matches = self.find_fuzzy_matches(id)?;
+                match fuzzy_matches.len() {
+                    0 => Err(anyhow!(
+                        "change not found: '{}'\n\
+                         Run 'docket list' to see all changes, or 'docket new' to create one.",
+                        id
+                    )),
+                    1 => {
+                        let events = self.read_from_state_branch(&fuzzy_matches[0])?;
+                        event::derive_change(&events)
+                    }
+                    _ => Err(anyhow!(
+                        "ambiguous change ID '{}', fuzzy matches: {}",
+                        id,
+                        fuzzy_matches.join(", ")
+                    )),
+                }
+            }
             1 => {
                 let events = self.read_from_state_branch(&prefix_matches[0])?;
                 event::derive_change(&events)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,67 +2,92 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
 
 fn docket_cmd() -> Command {
     cargo_bin_cmd!("docket")
 }
 
+/// Check if jj is available on this system.
+fn jj_available() -> bool {
+    std::process::Command::new("jj")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Set up a docket repo with jj initialized (StateBranch mode).
+/// Panics if jj is not installed.
 fn setup_docket_repo() -> TempDir {
+    if !jj_available() {
+        panic!(
+            "jj is required to run tests. Install from: https://martinvonz.github.io/jj/latest/install-and-setup/"
+        );
+    }
+
     let dir = TempDir::new().unwrap();
+
+    // Initialize jj repository
+    std::process::Command::new("jj")
+        .args(["git", "init"])
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to run jj git init");
+
+    // Initialize docket (will create state branch)
     docket_cmd()
         .current_dir(dir.path())
         .arg("init")
         .assert()
         .success();
+
     dir
+}
+
+/// List files on the docket-state branch matching a pattern.
+fn list_state_files(dir: &Path, pattern: &str) -> Vec<String> {
+    let output = std::process::Command::new("jj")
+        .args(["file", "list", "-r", "docket-state", pattern])
+        .current_dir(dir)
+        .output()
+        .expect("failed to run jj file list");
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Read a file from the docket-state branch.
+fn read_state_file(dir: &Path, path: &str) -> String {
+    let output = std::process::Command::new("jj")
+        .args(["file", "show", "-r", "docket-state", path])
+        .current_dir(dir)
+        .output()
+        .expect("failed to run jj file show");
+
+    String::from_utf8_lossy(&output.stdout).to_string()
 }
 
 mod init_command {
     use super::*;
 
     #[test]
-    fn init_creates_docket_directory() {
+    fn init_creates_state_branch() {
+        if !jj_available() {
+            panic!("jj is required to run tests");
+        }
+
         let dir = TempDir::new().unwrap();
 
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("init")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("Initialized docket"));
-
-        assert!(dir.path().join(".docket").exists());
-        assert!(dir.path().join(".docket/changes").exists());
-    }
-
-    #[test]
-    fn init_fails_if_already_initialized() {
-        let dir = setup_docket_repo();
-
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("init")
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains("already initialized"));
-    }
-
-    #[test]
-    fn init_creates_state_branch_in_jj_repo() {
-        let dir = TempDir::new().unwrap();
-
-        // Initialize a jj repository first
-        let jj_init = std::process::Command::new("jj")
+        // Initialize jj repository first
+        std::process::Command::new("jj")
             .args(["git", "init"])
             .current_dir(dir.path())
-            .output();
-
-        // Skip test if jj is not installed
-        if jj_init.is_err() || !jj_init.as_ref().unwrap().status.success() {
-            eprintln!("Skipping test: jj not installed or init failed");
-            return;
-        }
+            .output()
+            .expect("failed to run jj git init");
 
         // Get the current change id before init
         let before_output = std::process::Command::new("jj")
@@ -80,6 +105,7 @@ mod init_command {
             .arg("init")
             .assert()
             .success()
+            .stdout(predicate::str::contains("Initialized docket"))
             .stdout(predicate::str::contains("docket-state"))
             .stdout(predicate::str::contains("orphan state branch"));
 
@@ -97,17 +123,11 @@ mod init_command {
         );
 
         // Verify .docket/changes/.gitkeep exists on the state branch
-        let file_list_output = std::process::Command::new("jj")
-            .args(["file", "list", "-r", "docket-state"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        let files = String::from_utf8_lossy(&file_list_output.stdout);
-        // Normalize Windows backslashes to forward slashes for comparison
-        let files_normalized = files.replace('\\', "/");
+        let files = list_state_files(dir.path(), ".docket");
+        let files_str = files.join("\n").replace('\\', "/");
         assert!(
-            files_normalized.contains(".docket/changes/.gitkeep"),
-            ".docket/changes/.gitkeep should exist on state branch. Got: {}",
+            files_str.contains(".docket/changes/.gitkeep"),
+            ".docket/changes/.gitkeep should exist on state branch. Got: {:?}",
             files
         );
 
@@ -127,20 +147,15 @@ mod init_command {
     }
 
     #[test]
-    fn init_works_without_jj() {
-        let dir = TempDir::new().unwrap();
+    fn init_fails_if_already_initialized() {
+        let dir = setup_docket_repo();
 
-        // Just run docket init without jj - should still work
         docket_cmd()
             .current_dir(dir.path())
             .arg("init")
             .assert()
-            .success()
-            .stdout(predicate::str::contains("Initialized docket"));
-
-        // The basic .docket directory should exist
-        assert!(dir.path().join(".docket").exists());
-        assert!(dir.path().join(".docket/changes").exists());
+            .failure()
+            .stderr(predicate::str::contains("already initialized"));
     }
 }
 
@@ -158,10 +173,16 @@ mod new_command {
             .success()
             .stdout(predicate::str::contains("Created change"));
 
-        // Verify a .jsonl file was created
-        let bugs_dir = dir.path().join(".docket/changes");
-        let entries: Vec<_> = fs::read_dir(&bugs_dir).unwrap().collect();
-        assert_eq!(entries.len(), 1);
+        // Verify a .jsonl file was created on the state branch
+        let files = list_state_files(dir.path(), ".docket/changes");
+        // Filter to just .jsonl files (exclude .gitkeep)
+        let jsonl_files: Vec<_> = files.iter().filter(|f| f.ends_with(".jsonl")).collect();
+        assert_eq!(
+            jsonl_files.len(),
+            1,
+            "Expected 1 .jsonl file on state branch, got: {:?}",
+            files
+        );
     }
 
     #[test]
@@ -1373,164 +1394,18 @@ mod migrate_command {
     use super::*;
 
     #[test]
-    fn migrate_requires_jj_repo() {
+    fn migrate_is_idempotent_in_state_branch_mode() {
+        // setup_docket_repo() creates a jj repo and initializes docket in StateBranch mode
         let dir = setup_docket_repo();
 
-        // Without a jj repo, migrate should fail
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("migrate")
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains("requires a jj repository"));
-    }
-
-    #[test]
-    fn migrate_moves_changes_to_state_branch() {
-        let dir = TempDir::new().unwrap();
-
-        // Initialize a jj repository first
-        let jj_init = std::process::Command::new("jj")
-            .args(["git", "init"])
-            .current_dir(dir.path())
-            .output();
-
-        // Skip test if jj is not installed
-        if jj_init.is_err() || !jj_init.as_ref().unwrap().status.success() {
-            eprintln!("Skipping test: jj not installed or init failed");
-            return;
-        }
-
-        // Initialize docket (this creates .docket in working tree AND state branch)
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("init")
-            .assert()
-            .success();
-
-        // Create a couple of changes
-        docket_cmd()
-            .current_dir(dir.path())
-            .args(["new", "--title", "First change"])
-            .assert()
-            .success();
-
-        docket_cmd()
-            .current_dir(dir.path())
-            .args(["new", "--title", "Second change"])
-            .assert()
-            .success();
-
-        // Get the change IDs from the list
-        let list_output = docket_cmd()
-            .current_dir(dir.path())
-            .arg("list")
-            .output()
-            .unwrap();
-        let list_stdout = String::from_utf8_lossy(&list_output.stdout);
-
-        // Verify changes exist
-        assert!(
-            list_stdout.contains("First change"),
-            "First change should exist before migration"
-        );
-        assert!(
-            list_stdout.contains("Second change"),
-            "Second change should exist before migration"
-        );
-
-        // Verify .docket exists in working tree before migration
-        assert!(
-            dir.path().join(".docket").exists(),
-            ".docket should exist in working tree before migration"
-        );
-
-        // Run migrate
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("migrate")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("Migration complete"))
-            .stdout(predicate::str::contains("changes"));
-
-        // Verify .docket is removed from working tree
-        assert!(
-            !dir.path().join(".docket").exists(),
-            ".docket should be removed from working tree after migration"
-        );
-
-        // Verify the state branch has the data
-        let file_list = std::process::Command::new("jj")
-            .args(["file", "list", "-r", "docket-state"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        let files = String::from_utf8_lossy(&file_list.stdout);
-        // Normalize Windows backslashes to forward slashes for comparison
-        let files_normalized = files.replace('\\', "/");
-        assert!(
-            files_normalized.contains(".docket/changes/"),
-            "State branch should contain .docket/changes/"
-        );
-
-        // Verify we can still list changes (now from state branch)
-        let list_after = docket_cmd()
-            .current_dir(dir.path())
-            .arg("list")
-            .output()
-            .unwrap();
-        let list_after_stdout = String::from_utf8_lossy(&list_after.stdout);
-
-        assert!(
-            list_after_stdout.contains("First change"),
-            "First change should exist after migration"
-        );
-        assert!(
-            list_after_stdout.contains("Second change"),
-            "Second change should exist after migration"
-        );
-    }
-
-    #[test]
-    fn migrate_is_idempotent() {
-        let dir = TempDir::new().unwrap();
-
-        // Initialize a jj repository first
-        let jj_init = std::process::Command::new("jj")
-            .args(["git", "init"])
-            .current_dir(dir.path())
-            .output();
-
-        // Skip test if jj is not installed
-        if jj_init.is_err() || !jj_init.as_ref().unwrap().status.success() {
-            eprintln!("Skipping test: jj not installed or init failed");
-            return;
-        }
-
-        // Initialize docket
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("init")
-            .assert()
-            .success();
-
-        // Create a change
+        // Create some changes
         docket_cmd()
             .current_dir(dir.path())
             .args(["new", "--title", "Test change"])
             .assert()
             .success();
 
-        // Run migrate first time
-        docket_cmd()
-            .current_dir(dir.path())
-            .arg("migrate")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("Migration complete"));
-
-        // Run migrate second time - should succeed but indicate already migrated
+        // Running migrate when already in StateBranch mode should succeed
         docket_cmd()
             .current_dir(dir.path())
             .arg("migrate")
@@ -1540,29 +1415,131 @@ mod migrate_command {
     }
 
     #[test]
-    fn migrate_preserves_event_history() {
-        let dir = TempDir::new().unwrap();
-
-        // Initialize a jj repository first
-        let jj_init = std::process::Command::new("jj")
-            .args(["git", "init"])
-            .current_dir(dir.path())
-            .output();
-
-        // Skip test if jj is not installed
-        if jj_init.is_err() || !jj_init.as_ref().unwrap().status.success() {
-            eprintln!("Skipping test: jj not installed or init failed");
-            return;
+    fn migrate_from_filesystem_to_state_branch() {
+        if !jj_available() {
+            panic!("jj is required to run tests");
         }
 
-        // Initialize docket
+        let dir = TempDir::new().unwrap();
+
+        // Step 1: Create a docket repo WITHOUT jj first (FileSystem mode)
         docket_cmd()
             .current_dir(dir.path())
             .arg("init")
             .assert()
             .success();
 
-        // Create a change and make some updates to create history
+        // Create a change in FileSystem mode
+        docket_cmd()
+            .current_dir(dir.path())
+            .args(["new", "--title", "Pre-migration change"])
+            .assert()
+            .success();
+
+        // Verify .docket exists in working tree (FileSystem mode)
+        assert!(
+            dir.path().join(".docket/changes").exists(),
+            ".docket/changes should exist in working tree in FileSystem mode"
+        );
+
+        // Step 2: Initialize jj repo (but don't re-init docket)
+        std::process::Command::new("jj")
+            .args(["git", "init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("failed to init jj");
+
+        // Step 3: Run migrate to move to StateBranch mode
+        docket_cmd()
+            .current_dir(dir.path())
+            .arg("migrate")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Migration complete"));
+
+        // Verify .docket is removed from working tree
+        // (Note: .docket/templates may still exist, but .docket/changes should not)
+        let changes_dir = dir.path().join(".docket/changes");
+        // In FileSystem mode, the changes dir would have .jsonl files
+        // After migration, it should either not exist or only have files on state branch
+        let jsonl_files: Vec<_> = if changes_dir.exists() {
+            fs::read_dir(&changes_dir)
+                .map(|entries| {
+                    entries
+                        .filter_map(|e| e.ok())
+                        .filter(|e| {
+                            e.path()
+                                .extension()
+                                .map(|ext| ext == "jsonl")
+                                .unwrap_or(false)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            vec![]
+        };
+        assert!(
+            jsonl_files.is_empty(),
+            "No .jsonl files should remain in working tree after migration"
+        );
+
+        // Verify the state branch has the data
+        let files = list_state_files(dir.path(), ".docket/changes");
+        let jsonl_on_branch: Vec<_> = files.iter().filter(|f| f.ends_with(".jsonl")).collect();
+        assert!(
+            !jsonl_on_branch.is_empty(),
+            "State branch should contain change files"
+        );
+
+        // Verify we can still access the change
+        docket_cmd()
+            .current_dir(dir.path())
+            .arg("list")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Pre-migration change"));
+    }
+
+    // Test that migrate requires jj when starting in FileSystem mode
+    #[test]
+    fn migrate_requires_jj_when_in_filesystem_mode() {
+        // Create a docket repo without jj (FileSystem mode only)
+        let dir = TempDir::new().unwrap();
+
+        // Initialize docket without jj - this creates FileSystem mode
+        docket_cmd()
+            .current_dir(dir.path())
+            .arg("init")
+            .assert()
+            .success();
+
+        // Running migrate should fail since we need jj to migrate TO
+        docket_cmd()
+            .current_dir(dir.path())
+            .arg("migrate")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("requires a jj repository"));
+    }
+
+    // Test that event history is preserved during migration
+    #[test]
+    fn migrate_preserves_event_history() {
+        if !jj_available() {
+            panic!("jj is required to run tests");
+        }
+
+        let dir = TempDir::new().unwrap();
+
+        // Step 1: Create docket in FileSystem mode (no jj)
+        docket_cmd()
+            .current_dir(dir.path())
+            .arg("init")
+            .assert()
+            .success();
+
+        // Create a change and make updates to create history
         let new_output = docket_cmd()
             .current_dir(dir.path())
             .args(["new", "--title", "Change with history"])
@@ -1570,14 +1547,13 @@ mod migrate_command {
             .unwrap();
         let new_stdout = String::from_utf8_lossy(&new_output.stdout);
 
-        // Extract the change ID from output like "✓ Created change abcd - Title"
         let change_id = new_stdout
             .lines()
             .find(|l| l.contains("Created change"))
-            .and_then(|l| l.split_whitespace().nth(3)) // Get the ID: ✓(0) Created(1) change(2) ID(3)
+            .and_then(|l| l.split_whitespace().nth(3))
             .unwrap();
 
-        // Update the change to create more events
+        // Update to create more events
         docket_cmd()
             .current_dir(dir.path())
             .args(["update", change_id, "--priority", "high"])
@@ -1590,11 +1566,10 @@ mod migrate_command {
             .assert()
             .success();
 
-        // Read the change file before migration to count events
+        // Count events before migration (FileSystem mode stores in working dir)
         let change_path = dir
             .path()
-            .join(".docket")
-            .join("changes")
+            .join(".docket/changes")
             .join(&change_id[..1])
             .join(format!("{}.jsonl", change_id));
         let content_before = fs::read_to_string(&change_path).unwrap();
@@ -1603,53 +1578,43 @@ mod migrate_command {
             .filter(|l| !l.trim().is_empty())
             .count();
 
-        // Run migrate
+        // Step 2: Initialize jj
+        std::process::Command::new("jj")
+            .args(["git", "init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("failed to init jj");
+
+        // Step 3: Run migrate
         docket_cmd()
             .current_dir(dir.path())
             .arg("migrate")
             .assert()
-            .success();
+            .success()
+            .stdout(predicate::str::contains("Migration complete"));
 
-        // Read the events directly from state branch after migration
-        let state_file_output = std::process::Command::new("jj")
-            .args([
-                "file",
-                "show",
-                "-r",
-                "docket-state",
-                &format!(".docket/changes/{}/{}.jsonl", &change_id[..1], change_id),
-            ])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        let content_after = String::from_utf8_lossy(&state_file_output.stdout);
+        // Step 4: Verify events preserved on state branch
+        let content_after = read_state_file(
+            dir.path(),
+            &format!(".docket/changes/{}/{}.jsonl", &change_id[..1], change_id),
+        );
         let events_after = content_after
             .lines()
             .filter(|l| !l.trim().is_empty())
             .count();
 
         assert_eq!(
-            events_before,
-            events_after,
-            "Event history should be preserved after migration.\n\
-             Before ({} events): {}\n\
-             After ({} events): {}",
-            events_before,
-            content_before.trim(),
-            events_after,
-            content_after.trim()
+            events_before, events_after,
+            "Event history should be preserved. Before: {}, After: {}",
+            events_before, events_after
         );
 
-        // Also verify we can list the change after migration (uses state branch)
-        let list_after = docket_cmd()
+        // Verify change is still accessible
+        docket_cmd()
             .current_dir(dir.path())
             .arg("list")
-            .output()
-            .unwrap();
-        let list_stdout = String::from_utf8_lossy(&list_after.stdout);
-        assert!(
-            list_stdout.contains("Change with history"),
-            "Change should be listed after migration"
-        );
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Change with history"));
     }
 }


### PR DESCRIPTION
The implementation had several bugs that prevented StateBranch mode from working correctly:

1. `write_to_state_branch()` used non-existent `jj file write` command. Fixed to use the working copy approach: edit state branch, write file, describe (commits), then return to original change.

2. `Store::open_from()` checked for `.docket` directory before checking for state branch. Since `docket init` creates `.docket/templates/` in the working directory even in jj mode, this caused FileSystem mode to be incorrectly selected. Fixed to check for state branch first.

3. ID resolution functions (`resolve_id`, `get_change`, `generate_id`) didn't have StateBranch support. Added proper dispatching and implementations for StateBranch mode, including fuzzy matching.

4. Tests used FileSystem mode because `setup_docket_repo()` didn't initialize jj. Updated to initialize jj first so tests exercise StateBranch mode. Also updated migrate tests to properly test FileSystem -> StateBranch migration.

All 149 tests pass.